### PR TITLE
docs: update quickstart link from CODE_OF_CONDUCT.md to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **Legion API** powers the community hub for Kimitri’s fans, providing endp
 
 ## Quick Start
 
-To run the Legion API locally, make contributions, or integrate it with your application, follow the  [Contribution Guidelines](./CODE_OF_CONDUCT.md).
+To run the Legion API locally, make contributions, or integrate it with your application, follow the  [Contribution Guidelines](./CONTRIBUTING.md).
 
 ## Security
 
@@ -23,10 +23,9 @@ For information on reporting security vulnerabilities in Legion API, see
 ## REST APIs
 
 Lists API endpoints for easier integration with your application. You can call the Legion API in any language. 
->⚠We do not provide sandbox URL. If you need endpoints to assist in developing your application, follow the [Contribution Guidelines](./CODE_OF_CONDUCT.md) to run Legion API locally.
+>⚠We do not provide sandbox URL. If you need endpoints to assist in developing your application, follow the [Contribution Guidelines](./CONTRIBUTING.md) to run Legion API locally.
 
 ### Authentication
-
 
 
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Changes Made

This PR updates the Quick Start section link in the README.md, changing it from CODE_OF_CONDUCT.md to CONTRIBUTING.md. The CONTRIBUTING.md file provides the correct guidelines for running the Legion API locally, aligning with the purpose of the Quick Start section. 

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
<!-- - [x] New feature -->
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
 - [x] Documentation update 

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [ ] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
