### PR TITLE
Add partial generic support in SchemaValidation.check and return field

### DIFF
--- a/src/lib/validator/Schema.Validation.ts
+++ b/src/lib/validator/Schema.Validation.ts
@@ -1,21 +1,22 @@
 import type { ValidationBase } from './Base.Validation'
 import type { ValidationResult } from './validation'
 
-export class SchemaValidation {
-	private schema: Record<string, ValidationBase>
+export class SchemaValidation<T extends Record<string, unknown>> {
+	private schema: Record<keyof T, ValidationBase>
 
-	public constructor(schema: Record<string, ValidationBase>) {
+	public constructor(schema: Record<keyof T, ValidationBase>) {
 		this.schema = schema
 	}
 
-	public check(data: Record<string, unknown>): ValidationResult {
+	public check(data: Partial<T>): ValidationResult {
 		for (const [key, validator] of Object.entries(this.schema)) {
 			const result = validator.check(data[key])
 
 			if (!result.success) {
 				return {
 					success: false,
-					failedValidator: result.failedValidator
+					failedValidator: result.failedValidator,
+					field: key
 				}
 			}
 		}

--- a/src/lib/validator/index.ts
+++ b/src/lib/validator/index.ts
@@ -10,8 +10,9 @@ export const validator = {
 	string: (): StringValidation => new StringValidation(),
 	number: (): NumberValidation => new NumberValidation(),
 	boolean: (): BooleanValidation => new BooleanValidation(),
-	schema: (schema: Record<string, ValidationBase>): SchemaValidation =>
-		new SchemaValidation(schema),
+	schema: <T extends Record<string, unknown>>(
+		schema: Record<keyof T, ValidationBase>
+	): SchemaValidation<T> => new SchemaValidation(schema),
 	object: (schema: Record<string, ValidationBase>): ObjectValidation =>
 		new ObjectValidation(schema),
 	arrayOf: (schema: ValidationBase): ArrayValidation =>

--- a/src/lib/validator/validation.d.ts
+++ b/src/lib/validator/validation.d.ts
@@ -1,5 +1,5 @@
 type ValidationResult =
 	| { success: true }
-	| { success: false; failedValidator: string }
+	| { success: false; failedValidator: string; field?: string }
 
 export type ValidatorFunction = (value: T) => ValidationResult


### PR DESCRIPTION
## Changes Made

This PR updates the check function to include generic support and partial type validation. 

- The `SchemaValidation.check()` method now supports generic types, enabling more flexible and type-safe validation for different data structures.
- Partial data validation is now supported, allowing the method to work with incomplete data (`Partial<T>`).
- Additionally, a `field` property was added to the method's return object. This enhancement provides more detailed feedback by specifying which data field failed validation and which validation rule was not met.

These changes improve type safety, usability, and the debugging experience during validation.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

- [x] Bug fix
<!-- - [x] New feature -->
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
