### PR TITLE
Kimitri

### DIFF
--- a/src/handlers/users/CreateUser/CreateUser.Handler.ts
+++ b/src/handlers/users/CreateUser/CreateUser.Handler.ts
@@ -1,4 +1,5 @@
 import type { User } from '@src/entities/User.Entity'
+import { AppError } from '@src/errors/AppErrors.Error'
 import { UserRepository } from '@src/repositories/users/User.Repository'
 import { CreateUserService } from '@src/services/users/CreateUser/CreateUser.Service'
 import type { Presenter } from '@src/types/presenter'
@@ -13,7 +14,12 @@ export const CreateUserHandler = factory.createHandlers(
 		const usersRepository = new UserRepository(c.env.DB)
 		const createUserService = new CreateUserService(usersRepository)
 
-		const data = await c.req.json()
+		const data = await c.req.json().catch(() => {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Invalid JSON format in request body'
+			})
+		})
 
 		const user = await createUserService.execute(data)
 

--- a/src/lib/validator/Schema.Validation.ts
+++ b/src/lib/validator/Schema.Validation.ts
@@ -3,12 +3,31 @@ import type { ValidationResult } from './validation'
 
 export class SchemaValidation<T extends Record<string, unknown>> {
 	private schema: Record<keyof T, ValidationBase>
+	private strict
 
-	public constructor(schema: Record<keyof T, ValidationBase>) {
+	public constructor(
+		schema: Record<keyof T, ValidationBase>,
+		options?: {
+			strict: boolean
+		}
+	) {
 		this.schema = schema
+		this.strict = options?.strict
 	}
 
 	public check(data: Partial<T>): ValidationResult {
+		if (this.strict) {
+			const extraKeys = Object.keys(data).filter((key) => !(key in this.schema))
+
+			if (extraKeys.length > 0) {
+				return {
+					success: false,
+					failedValidator: 'unknownPropertiesDetected',
+					field: extraKeys
+				}
+			}
+		}
+
 		for (const [key, validator] of Object.entries(this.schema)) {
 			const result = validator.check(data[key])
 

--- a/src/lib/validator/index.ts
+++ b/src/lib/validator/index.ts
@@ -11,8 +11,9 @@ export const validator = {
 	number: (): NumberValidation => new NumberValidation(),
 	boolean: (): BooleanValidation => new BooleanValidation(),
 	schema: <T extends Record<string, unknown>>(
-		schema: Record<keyof T, ValidationBase>
-	): SchemaValidation<T> => new SchemaValidation(schema),
+		schema: Record<keyof T, ValidationBase>,
+		options?: { strict: boolean }
+	): SchemaValidation<T> => new SchemaValidation(schema, options),
 	object: (schema: Record<string, ValidationBase>): ObjectValidation =>
 		new ObjectValidation(schema),
 	arrayOf: (schema: ValidationBase): ArrayValidation =>

--- a/src/lib/validator/validation.d.ts
+++ b/src/lib/validator/validation.d.ts
@@ -1,5 +1,5 @@
 type ValidationResult =
 	| { success: true }
-	| { success: false; failedValidator: string; field?: string }
+	| { success: false; failedValidator: string; field?: string | string[] }
 
 export type ValidatorFunction = (value: T) => ValidationResult

--- a/tests/handlers/users/CreateUser/Validation.failure.test.ts
+++ b/tests/handlers/users/CreateUser/Validation.failure.test.ts
@@ -447,4 +447,27 @@ describe('Create User Input Validation - E2E', () => {
 			}
 		})
 	})
+
+	test('should throw a Bad Request error when invalid JSON is provided', async () => {
+		const payload =
+			'{ name: "John Doe", username: "johndoe123", email: asdf@test.com, password: "randomPassword" }'
+
+		const res = await app.request(
+			'/users',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Invalid JSON format in request body'
+		})
+	})
 })

--- a/tests/lib/validator/Strict.test.ts
+++ b/tests/lib/validator/Strict.test.ts
@@ -1,0 +1,30 @@
+import { validator } from '@src/lib/validator'
+import { describe, expect, test } from 'vitest'
+
+describe('Validator Library', () => {
+	test('should reject additional properties when strict is enabled', () => {
+		const schema = validator.schema(
+			{
+				data: validator.boolean()
+			},
+			{
+				strict: true
+			}
+		)
+
+		const validData = { data: true }
+		const validResult = schema.check(validData)
+
+		const invalidData = { data: true, invalidField: 123 }
+		const invalidResult = schema.check(invalidData)
+
+		expect(validResult).toStrictEqual({
+			success: true
+		})
+		expect(invalidResult).toStrictEqual({
+			success: false,
+			failedValidator: 'unknownPropertiesDetected',
+			field: ['invalidField']
+		})
+	})
+})


### PR DESCRIPTION
## Changes Made
This PR introduces error handling for invalid JSON formats and adds a strict validation feature to the schema in the Validator library. The error handling now provides a specific message when the input body of a request is an invalid JSON, giving users more precise feedback.

In addition, the Validator library now supports strict validation, which allows schemas to reject additional properties not declared within the schema. This feature helps ensure that only the expected properties are accepted, making the validation process more reliable. To enable strict validation, you can pass a strict option when defining the schema, like so:
```typescript
import { validator } from '@src/lib/validator'

const schema = validator.schema(
	{
		data: validator.boolean()
	},
	{
		strict: true
	}
)
```

With this change, if an object contains properties that are not part of the schema, such as:

```typescript
const invalidData = { data: true, invalidField: 123 }
const invalidResult = schema.check(invalidData)
```

The validator will return an error similar to this:

```typescript
{
  success: false,
  failedValidator: 'unknownPropertiesDetected',
  field: ['invalidField']
}
```

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
