### PR TITLE
Add strict validation to createUserSchema

### DIFF
--- a/src/validations/users/CreateUser.Validation.ts
+++ b/src/validations/users/CreateUser.Validation.ts
@@ -1,8 +1,13 @@
 import { validator } from '@src/lib/validator'
 
-export const createUserSchema = validator.schema({
-	name: validator.string().max(256).min(1),
-	username: validator.string().max(256).min(1),
-	password: validator.string().max(256).min(8).nullable(),
-	email: validator.string().email().max(256).nullable()
-})
+export const createUserSchema = validator.schema(
+	{
+		name: validator.string().max(256).min(1),
+		username: validator.string().max(256).min(1),
+		password: validator.string().max(256).min(8).nullable(),
+		email: validator.string().email().max(256).nullable()
+	},
+	{
+		strict: true
+	}
+)

--- a/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
+++ b/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
@@ -5,7 +5,7 @@ import app from '@src/index'
 import { UserRepository } from '@src/repositories/users/User.Repository'
 import { CreateUserService } from '@src/services/users/CreateUser/CreateUser.Service'
 import { drizzle } from 'drizzle-orm/d1'
-import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+import { afterEach, beforeAll, describe, expect, test, vitest } from 'vitest'
 
 describe('Create User failure tests', () => {
 	const db = drizzle(env.DB)
@@ -27,6 +27,21 @@ describe('Create User failure tests', () => {
 		const usersRepository = new UserRepository(env.DB)
 		const createUserService = new CreateUserService(usersRepository)
 
+		vitest.spyOn(usersRepository, 'findOneByOr').mockResolvedValueOnce([
+			{
+				id: '01JHBDWAXFPAKAFK38E1MAM01W',
+				name: 'John Doe',
+				username: 'johndoe123',
+				password: 'secureP@ssw0rd!',
+				email: 'johndoe@example.com',
+				isActive: true,
+				isDeleted: false,
+				kats: 0,
+				rank: 0,
+				createdAt: new Date().toISOString()
+			}
+		])
+
 		await db.insert(users).values({
 			id: '01JHBDWAXFPAKAFK38E1MAM01W',
 			name: 'John Doe',
@@ -40,15 +55,10 @@ describe('Create User failure tests', () => {
 			createdAt: new Date().toISOString()
 		})
 
-		const payload: IUsersDTO = {
-			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+		const payload = {
 			name: 'John Doe',
-			username: 'johndoe1234',
-			email: 'johndoe@example.com',
-			createdAt: new Date().toISOString(),
-			isActive: true,
-			isDeleted: false
-		}
+			username: 'johndoe1234'
+		} as IUsersDTO
 
 		await expect(createUserService.execute(payload)).rejects.toThrowError(
 			'This user already exists'

--- a/tests/handlers/users/CreateUser/Validation.failure.test.ts
+++ b/tests/handlers/users/CreateUser/Validation.failure.test.ts
@@ -448,6 +448,36 @@ describe('Create User Input Validation - E2E', () => {
 		})
 	})
 
+	test('should fail when there is a property not defined in the schema', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'johndoe123',
+			test: '1234567'
+		})
+
+		const res = await app.request(
+			'/users',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				cause: 'is not unknownPropertiesDetected',
+				field: ['test']
+			}
+		})
+	})
+
 	test('should throw a Bad Request error when invalid JSON is provided', async () => {
 		const payload =
 			'{ name: "John Doe", username: "johndoe123", email: asdf@test.com, password: "randomPassword" }'


### PR DESCRIPTION
## Changes Made

This PR adds strict validation to the `createUserSchema`. By enabling the `strict: true` option, the schema now rejects any additional properties that are not explicitly defined in the `createUserSchema` during validation for the create user endpoint. This ensures that only the defined fields are accepted, enhancing data integrity and ensuring consistent validation.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
