### PR TITLE
Implement update user endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The **Legion API** powers the community hub for Kimitri’s fans, providing endp
 - [Quick Start](#quick-start)
 - [Security](#security)
 - [REST APIs](#rest-apis)
-    - [Authentication](#authentication)
+    - [Users](#users)
 - [Error Codes](#error-codes)
 
 ## Quick Start
@@ -28,7 +28,7 @@ Lists API endpoints for easier integration with your application. You can call t
 ### Users
 
 <details>
- <summary><code>POST</code> <code><b>/auth/user</b></code> <code>Create New User</code></summary>
+ <summary><code>POST</code> <code><b>/users</b></code> <code>Create New User</code></summary>
  
 #### Create New User
 Allows the creation of a new user in the Legion ecosystem.
@@ -45,7 +45,7 @@ Allows the creation of a new user in the Legion ecosystem.
 > | name          |  type     | Required | description                         |
 > |---------------|-----------|----------|-------------------------------------|
 > | name          |  string   |**yes**| 	The name for the new user. |
-> | username      |  string   |**yes**| 	The user for the new user. |
+> | username      |  string   |**yes**| 	The username for the new user. |
 > | password      |  string   |**no** | 	The password for the user. |
 > | email         |  string   |**no** | 	The email for the user.    |
 
@@ -88,6 +88,73 @@ Allows the creation of a new user in the Legion ecosystem.
 
 
 </details>
+
+<details>
+ <summary><code>POST</code> <code><b>/users/{userId}</b></code> <code>Update User</code></summary>
+ 
+#### Update User
+Allows updating user data but prevents updates if the `username` or `email` already exists in another user's account.
+
+#### Request 
+
+> #### Header Parameters 
+> | name         |  required | description                                                                                          |
+> |--------------|-----------|------------------------------------------------------------------------------------------------------|
+> | Content-Type |  yes      | Required for operations with a request body. The value is application/. Where the 'format' is 'json'.|
+> | X-CSRF-Token |  yes      | A CSRF token to protect against cross-site request forgery attacks. Must be included in the request.|
+
+> #### Path Parameters
+> | Name | Type   | Required | Description                          |
+> |------|--------|----------|--------------------------------------|
+> | id   | string | **yes**  | The unique identifier of the user.  |
+
+> #### Body Schema
+> | name          |  type     | Required | description                         |
+> |---------------|-----------|----------|-------------------------------------|
+> | name          |  string   |**yes**| 	The name for the user. |
+> | username      |  string   |**yes**| 	The username for the user. |
+> | email         |  string   |**no** | 	The email for the user.    |
+
+#### Response 
+
+> #### Sample Successful Response 
+>
+> Status Code: `201` <br>
+> application/json
+>```json
+>{
+>    "success": true,
+>    "message": "User created successfully!",
+>    "data": {
+>      "id": "01JEVAG858D9NP6A1NMTKXPRRA",
+>      "name": "John Doe",
+>      "username": "jhondoe123",
+>      "email": "john.doe@example.com",
+>      "isActive": true,
+>      "isDeleted": false,
+>      "createdAt": "2025-01-13T03:14:41.000Z"
+>    }
+>}
+>```
+
+
+> #### Response Schema
+> application/json
+>| Key         | Type     | Description                                      |
+>|-------------|----------|--------------------------------------------------|
+>| success     | boolean  | Indicates whether the request was successful.    |
+>| message     | string   | A message providing additional context.          |
+>| data        | object   | Contains user authentication details.            |
+>| data.id       | string   | Unique identifier for the user (ulid format).  |
+>| data.name     | string   | Name for the user.                             |
+>| data.email    | string   | Email for the user.                            |
+>| data.isActive    | boolean   | Indicates if the user is currently active.                            |
+>| data.isDeleted    | boolean   | Indicates if the user has been marked as deleted.                           |
+>| data.createdAt    | string   | Date of the user was created (ISO 8601 format).    |
+
+
+</details>
+
 
 ------------------------------------------------------------------------------------------
 

--- a/src/handlers/users/UpdateUser/UpdateUser.Handler.ts
+++ b/src/handlers/users/UpdateUser/UpdateUser.Handler.ts
@@ -1,0 +1,38 @@
+import type { User } from '@src/entities/User.Entity'
+import { AppError } from '@src/errors/AppErrors.Error'
+import { UserRepository } from '@src/repositories/users/User.Repository'
+import { UpdateUserService } from '@src/services/users/UpdateUser/UpdateUser.Service'
+import type { Presenter } from '@src/types/presenter'
+import { factory } from '@src/utils/factory'
+import type { TypedResponse } from 'hono'
+import { logger } from 'hono/logger'
+import type { StatusCode } from 'hono/utils/http-status'
+
+export const UpdateUserHandler = factory.createHandlers(
+	logger(),
+	async (c): Promise<TypedResponse<Presenter<User>, StatusCode>> => {
+		const usersRepository = new UserRepository(c.env.DB)
+		const updateUserService = new UpdateUserService(usersRepository)
+
+		const id = c.req.param('id')
+		const body = await c.req.json().catch(() => {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Invalid JSON format in request body'
+			})
+		})
+
+		const data = { id, ...body }
+
+		const user = await updateUserService.execute(data)
+
+		return c.json(
+			{
+				success: true,
+				message: 'User updated successfully',
+				data: user
+			},
+			200
+		)
+	}
+)

--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -86,6 +86,39 @@ export class UserRepository {
 		return user[0]
 	}
 
+	public async update(data: User): Promise<User> {
+		const updatedUser = await this.db
+			.update(users)
+			.set({
+				name: data.name,
+				username: data.username,
+				email: data.email
+			})
+			.where(eq(users.id, data.id))
+
+		if (updatedUser.error) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: updatedUser.error
+			})
+		}
+
+		const user = await this.db
+			.select()
+			.from(users)
+			.where(eq(users.id, data.id))
+			.limit(1)
+
+		if (user.length === 0) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'User not found after update. Possible data inconsistency.'
+			})
+		}
+
+		return user[0]
+	}
+
 	public async delete(id: string): Promise<void> {
 		await this.db
 			.update(users)

--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -1,8 +1,9 @@
 import { users } from '@src/db/user.schema'
+import type { IUsersDTO } from '@src/dtos/User.DTO'
 import { User } from '@src/entities/User.Entity'
 import { AppError } from '@src/errors/AppErrors.Error'
 import type { FindByParams } from '@src/types/userRepository'
-import { eq, or } from 'drizzle-orm'
+import { and, eq, not, or } from 'drizzle-orm'
 import { type DrizzleD1Database, drizzle } from 'drizzle-orm/d1'
 
 export class UserRepository {
@@ -17,28 +18,35 @@ export class UserRepository {
 	public async findOneByOr({
 		id,
 		email,
-		username
+		username,
+		andNot
 	}: FindByParams): Promise<User[] | null> {
-		const conditions = []
+		const includeConditions = []
+		const excludeConditions = []
 
 		if (id) {
-			conditions.push(eq(users.id, id))
+			includeConditions.push(eq(users.id, id))
 		}
 		if (email) {
-			conditions.push(eq(users.email, email))
+			includeConditions.push(eq(users.email, email))
 		}
 		if (username) {
-			conditions.push(eq(users.username, username))
+			includeConditions.push(eq(users.username, username))
+		}
+		if (andNot) {
+			for (const [key, value] of Object.entries(andNot)) {
+				excludeConditions.push(not(eq(users[key as keyof IUsersDTO], value)))
+			}
 		}
 
-		if (conditions.length === 0) {
+		if (includeConditions.length === 0) {
 			return null
 		}
 
 		const getUser = await this.db
 			.select()
 			.from(users)
-			.where(or(...conditions))
+			.where(and(or(...includeConditions), ...excludeConditions))
 			.limit(1)
 
 		if (getUser.length === 0) {

--- a/src/routers/users.router.ts
+++ b/src/routers/users.router.ts
@@ -1,8 +1,10 @@
 import { CreateUserHandler } from '@src/handlers/users/CreateUser/CreateUser.Handler'
+import { UpdateUserHandler } from '@src/handlers/users/UpdateUser/UpdateUser.Handler'
 import { Hono } from 'hono'
 
 const usersRouters = new Hono()
 
 usersRouters.post('/users', ...CreateUserHandler)
+usersRouters.put('/users/:id', ...UpdateUserHandler)
 
 export default usersRouters

--- a/src/services/users/UpdateUser/UpdateUser.Service.ts
+++ b/src/services/users/UpdateUser/UpdateUser.Service.ts
@@ -1,0 +1,85 @@
+import type { IUsersDTO } from '@src/dtos/User.DTO'
+import { User } from '@src/entities/User.Entity'
+import { AppError } from '@src/errors/AppErrors.Error'
+import type { UserRepository } from '@src/repositories/users/User.Repository'
+import { updateUserSchema } from '@src/validations/users/UpdateUser.Validation'
+
+export class UpdateUserService {
+	public constructor(private readonly userRepository: UserRepository) {}
+
+	public async execute(data: IUsersDTO): Promise<User> {
+		this.validation(data)
+
+		const user = new User(data)
+
+		await this.ensureUserExists(data.id)
+
+		await this.checkForConflict(user)
+
+		const updatedUser = await this.userRepository.update(user)
+
+		return this.sanitizeUser(updatedUser)
+	}
+
+	private sanitizeUser(user: User): User {
+		user.password = undefined
+		user.kats = undefined
+		user.rank = undefined
+
+		return user
+	}
+
+	private async ensureUserExists(userId: string): Promise<User> {
+		const user = await this.userRepository.findOneByOr({ id: userId })
+
+		if (!user) {
+			throw new AppError({
+				name: 'Not Found',
+				message: 'User not founded!',
+				cause: {
+					id: userId
+				}
+			})
+		}
+
+		return user[0]
+	}
+
+	private async checkForConflict(user: User): Promise<void> {
+		const existingUser = await this.userRepository.findOneByOr({
+			email: user.email,
+			username: user.username,
+			andNot: {
+				id: user.id
+			}
+		})
+
+		if (existingUser && existingUser.length !== 0) {
+			const conflictField =
+				existingUser[0].username === user.username ? 'username' : 'email'
+
+			throw new AppError({
+				name: 'Conflict',
+				message: 'This user already exists',
+				cause: {
+					[conflictField]: existingUser[0][conflictField]
+				}
+			})
+		}
+	}
+
+	private validation(data: IUsersDTO): void {
+		const isValidData = updateUserSchema.check(data)
+
+		if (!isValidData.success) {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Validation failed',
+				cause: {
+					field: isValidData.field,
+					cause: `is not ${isValidData.failedValidator}`
+				}
+			})
+		}
+	}
+}

--- a/src/types/userRepository.ts
+++ b/src/types/userRepository.ts
@@ -1,5 +1,13 @@
+import type { IUsersDTO } from '@src/dtos/User.DTO'
+
 export type FindByParams = {
 	id?: string
 	email?: string | null
 	username?: string | null
-} & ({ id: string } | { email: string } | { username: string })
+	andNot?: Partial<Record<keyof IUsersDTO, string>>
+} & (
+	| { id: string }
+	| { email: string }
+	| { username: string }
+	| { andNot: Partial<Record<keyof IUsersDTO, string>> }
+)

--- a/src/validations/users/UpdateUser.Validation.ts
+++ b/src/validations/users/UpdateUser.Validation.ts
@@ -1,0 +1,13 @@
+import { validator } from '@src/lib/validator'
+
+export const updateUserSchema = validator.schema(
+	{
+		id: validator.string().ulid(),
+		name: validator.string().max(256).min(1),
+		username: validator.string().max(256).min(1),
+		email: validator.string().email().max(256).nullable()
+	},
+	{
+		strict: true
+	}
+)

--- a/tests/handlers/users/UpdateUser/AlreadyExists.failure.test.ts
+++ b/tests/handlers/users/UpdateUser/AlreadyExists.failure.test.ts
@@ -1,0 +1,131 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Update User failure tests', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when user with username already exists - E2E', async () => {
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			isDeleted: false,
+			kats: 0,
+			rank: 0,
+			createdAt: new Date().toISOString()
+		})
+
+		await db.insert(users).values({
+			id: '01JHQREHTPYRX3390EVFXX47N3',
+			name: 'Mary Doe',
+			username: 'marydoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'marydoe@example.com',
+			isActive: true,
+			isDeleted: false,
+			kats: 0,
+			rank: 0,
+			createdAt: new Date().toISOString()
+		})
+
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'marydoe123'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(409)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'This user already exists',
+			cause: {
+				username: 'marydoe123'
+			}
+		})
+	})
+
+	test('should fail when user with email already exists - E2E', async () => {
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			isDeleted: false,
+			kats: 0,
+			rank: 0,
+			createdAt: new Date().toISOString()
+		})
+
+		await db.insert(users).values({
+			id: '01JHQREHTPYRX3390EVFXX47N3',
+			name: 'Mary Doe',
+			username: 'marydoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'marydoe@example.com',
+			isActive: true,
+			isDeleted: false,
+			kats: 0,
+			rank: 0,
+			createdAt: new Date().toISOString()
+		})
+
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'johndoe1234',
+			email: 'marydoe@example.com'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(409)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'This user already exists',
+			cause: {
+				email: 'marydoe@example.com'
+			}
+		})
+	})
+})

--- a/tests/handlers/users/UpdateUser/Success.test.ts
+++ b/tests/handlers/users/UpdateUser/Success.test.ts
@@ -1,0 +1,71 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Update User handler E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should update user successfully with username, password and email', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			isDeleted: false,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			name: 'Mary Doe',
+			username: 'marydoe123',
+			email: 'marydoe@example.com'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'User updated successfully',
+			data: {
+				id: '01JHBDWAXFPAKAFK38E1MAM01W',
+				name: 'Mary Doe',
+				username: 'marydoe123',
+				email: 'marydoe@example.com',
+				isActive: true,
+				isDeleted: false,
+				createdAt: date
+			}
+		})
+	})
+})

--- a/tests/handlers/users/UpdateUser/Validation.failure.test.ts
+++ b/tests/handlers/users/UpdateUser/Validation.failure.test.ts
@@ -1,0 +1,404 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Update User Input Validation - E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when name is not a string', async () => {
+		const payload = JSON.stringify({
+			name: 1234,
+			username: 'johndoe123',
+			email: 'exemple@exemple.com'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'name',
+				cause: 'is not string'
+			}
+		})
+	})
+
+	test('should fail when name exceeds the maximum length of 256 characters', async () => {
+		const longName = 'a'.repeat(257)
+
+		const payload = JSON.stringify({
+			name: longName,
+			username: 'johndoe123'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'name',
+				cause: 'is not max'
+			}
+		})
+	})
+
+	test('should fail when name is shorter than the minimum length of 1 characters', async () => {
+		const payload = JSON.stringify({
+			name: '',
+			username: 'johndoe123'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'name',
+				cause: 'is not min'
+			}
+		})
+	})
+
+	test('should fail when name is undefined', async () => {
+		const payload = JSON.stringify({
+			name: undefined,
+			username: 'johndoe123'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'name',
+				cause: 'is not nullable'
+			}
+		})
+	})
+
+	test('should fail when username is not a string', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 1234
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'username',
+				cause: 'is not string'
+			}
+		})
+	})
+
+	test('should fail when username exceeds the maximum length of 256 characters', async () => {
+		const longName = 'a'.repeat(257)
+
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: longName
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'username',
+				cause: 'is not max'
+			}
+		})
+	})
+
+	test('should fail when username is shorter than the minimum length of 1 characters', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: ''
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'username',
+				cause: 'is not min'
+			}
+		})
+	})
+
+	test('should fail when username is undefined', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: undefined
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'username',
+				cause: 'is not nullable'
+			}
+		})
+	})
+
+	test('should fail when email is not a string', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'johndoe123',
+			email: 1234
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'email',
+				cause: 'is not string'
+			}
+		})
+	})
+
+	test('should fail when email exceeds the maximum length of 256 characters', async () => {
+		const longPassword = 'a'.repeat(257)
+
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'johndoe123',
+			email: `test@test.com${longPassword}`
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'email',
+				cause: 'is not max'
+			}
+		})
+	})
+
+	test('should fail when email is not email format', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'johndoe123',
+			email: '1234567'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'email',
+				cause: 'is not email'
+			}
+		})
+	})
+
+	test('should fail when there is a property not defined in the schema', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'johndoe123',
+			test: '1234567'
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				cause: 'is not unknownPropertiesDetected',
+				field: ['test']
+			}
+		})
+	})
+
+	test('should throw a Bad Request error when invalid JSON is provided', async () => {
+		const payload =
+			'{ name: "John Doe", username: "johndoe123", email: asdf@test.com, password: "randomPassword" }'
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'PUT',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Invalid JSON format in request body'
+		})
+	})
+})


### PR DESCRIPTION
## Changes Made
This PR implements the update user endpoint, allowing updates to a user's `username`, `name`, and `email`. To ensure that users cannot update their `username` or `email` to values already in use by another user, an exclusion condition was added to the `findOneByOr` repository method.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
- [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
- [x] Documentation update

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
