### PR TITLE
Replace isDeleted (boolean) to deletedAt (date)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Allows the creation of a new user in the Legion ecosystem.
 >      "username": "jhondoe123",
 >      "email": "john.doe@example.com",
 >      "isActive": true,
->      "isDeleted": false,
 >      "createdAt": "2025-01-13T03:14:41.000Z"
 >    }
 >}
@@ -83,7 +82,6 @@ Allows the creation of a new user in the Legion ecosystem.
 >| data.name     | string   | Name for the created user.                             |
 >| data.email    | string   | Email for the created user.                            |
 >| data.isActive    | boolean   | Indicates if the user is currently active.                            |
->| data.isDeleted    | boolean   | Indicates if the user has been marked as deleted.                           |
 >| data.createdAt    | string   | Date of the user was created (ISO 8601 format).    |
 
 
@@ -131,7 +129,6 @@ Allows updating user data but prevents updates if the `username` or `email` alre
 >      "username": "jhondoe123",
 >      "email": "john.doe@example.com",
 >      "isActive": true,
->      "isDeleted": false,
 >      "createdAt": "2025-01-13T03:14:41.000Z"
 >    }
 >}
@@ -149,7 +146,6 @@ Allows updating user data but prevents updates if the `username` or `email` alre
 >| data.name     | string   | Name for the user.                             |
 >| data.email    | string   | Email for the user.                            |
 >| data.isActive    | boolean   | Indicates if the user is currently active.                            |
->| data.isDeleted    | boolean   | Indicates if the user has been marked as deleted.                           |
 >| data.createdAt    | string   | Date of the user was created (ISO 8601 format).    |
 
 

--- a/src/db/user.schema.ts
+++ b/src/db/user.schema.ts
@@ -1,4 +1,3 @@
-import { sql } from 'drizzle-orm'
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const users = sqliteTable('users', {
@@ -10,6 +9,6 @@ export const users = sqliteTable('users', {
 	kats: integer().default(0),
 	rank: integer(),
 	isActive: integer({ mode: 'boolean' }).notNull().default(true),
-	isDeleted: integer({ mode: 'boolean' }).notNull().default(false),
-	createdAt: text().default(sql`CURRENT_TIMESTAMP`).notNull()
+	createdAt: text().notNull(),
+	deletedAt: text({ length: 24 })
 })

--- a/src/dtos/User.DTO.ts
+++ b/src/dtos/User.DTO.ts
@@ -7,6 +7,6 @@ export interface IUsersDTO {
 	kats?: number | null
 	rank?: number | null
 	isActive: boolean
-	isDeleted: boolean
 	createdAt: string
+	deletedAt?: string | null
 }

--- a/src/entities/User.Entity.ts
+++ b/src/entities/User.Entity.ts
@@ -9,8 +9,8 @@ export class User {
 	public kats?: number | null
 	public rank?: number | null
 	public isActive!: boolean
-	public isDeleted!: boolean
 	public createdAt!: string
+	public deletedAt?: string | null
 
 	public constructor(props: Omit<User, 'id'>) {
 		Object.assign(this, props)

--- a/src/migrations/0002_migration.sql
+++ b/src/migrations/0002_migration.sql
@@ -1,0 +1,18 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_users` (
+	`id` text NOT NULL,
+	`name` text(256) NOT NULL,
+	`username` text(256) NOT NULL,
+	`password` text(256),
+	`email` text(256),
+	`kats` integer DEFAULT 0,
+	`rank` integer,
+	`isActive` integer DEFAULT true NOT NULL,
+	`createdAt` text NOT NULL,
+	`deletedAt` text(24)
+);
+--> statement-breakpoint
+INSERT INTO `__new_users`("id", "name", "username", "password", "email", "kats", "rank", "isActive", "createdAt", "deletedAt") SELECT "id", "name", "username", "password", "email", "kats", "rank", "isActive", "createdAt", "deletedAt" FROM `users`;--> statement-breakpoint
+DROP TABLE `users`;--> statement-breakpoint
+ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/src/migrations/meta/0002_snapshot.json
+++ b/src/migrations/meta/0002_snapshot.json
@@ -1,0 +1,102 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "aa0f2471-df19-45cd-aad4-11c98861d014",
+	"prevId": "d5b41ac5-9abc-44df-80bd-79fd0dfbe714",
+	"tables": {
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"kats": {
+					"name": "kats",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isActive": {
+					"name": "isActive",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {
+			"\"users\".\"isDeleted\"": "\"users\".\"deletedAt\""
+		}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/migrations/meta/_journal.json
+++ b/src/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1736561247397,
 			"tag": "0001_migration",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "6",
+			"when": 1737056672014,
+			"tag": "0002_migration",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -123,7 +123,7 @@ export class UserRepository {
 		await this.db
 			.update(users)
 			.set({
-				isDeleted: true
+				deletedAt: new Date().toISOString()
 			})
 			.where(eq(users.id, id))
 	}

--- a/src/services/users/CreateUser/CreateUser.Service.ts
+++ b/src/services/users/CreateUser/CreateUser.Service.ts
@@ -30,6 +30,7 @@ export class CreateUserService {
 		user.kats = undefined
 		user.rank = undefined
 		user.email = user.email === null ? undefined : user.email
+		user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
 
 		return user
 	}

--- a/src/services/users/UpdateUser/UpdateUser.Service.ts
+++ b/src/services/users/UpdateUser/UpdateUser.Service.ts
@@ -23,6 +23,7 @@ export class UpdateUserService {
 		user.password = undefined
 		user.kats = undefined
 		user.rank = undefined
+		user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
 
 		return user
 	}

--- a/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
+++ b/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
@@ -35,7 +35,7 @@ describe('Create User failure tests', () => {
 				password: 'secureP@ssw0rd!',
 				email: 'johndoe@example.com',
 				isActive: true,
-				isDeleted: false,
+				deletedAt: null,
 				kats: 0,
 				rank: 0,
 				createdAt: new Date().toISOString()
@@ -49,7 +49,7 @@ describe('Create User failure tests', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: new Date().toISOString()
@@ -73,7 +73,7 @@ describe('Create User failure tests', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: new Date().toISOString()
@@ -115,7 +115,7 @@ describe('Create User failure tests', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: new Date().toISOString()

--- a/tests/handlers/users/CreateUser/Success.test.ts
+++ b/tests/handlers/users/CreateUser/Success.test.ts
@@ -57,7 +57,6 @@ describe('Create User handler E2E', () => {
 				username: 'johndoe123',
 				email: 'johndoe@example.com',
 				isActive: true,
-				isDeleted: false,
 				createdAt: user.createdAt
 			}
 		})
@@ -96,7 +95,6 @@ describe('Create User handler E2E', () => {
 				name: 'John Doe',
 				username: 'johndoe123',
 				isActive: true,
-				isDeleted: false,
 				createdAt: user.createdAt
 			}
 		})
@@ -137,7 +135,6 @@ describe('Create User handler E2E', () => {
 				username: 'johndoe123',
 				email: 'johndoe@example.com',
 				isActive: true,
-				isDeleted: false,
 				createdAt: user.createdAt
 			}
 		})
@@ -177,7 +174,6 @@ describe('Create User handler E2E', () => {
 				name: 'John Doe',
 				username: 'johndoe123',
 				isActive: true,
-				isDeleted: false,
 				createdAt: user.createdAt
 			}
 		})

--- a/tests/handlers/users/UpdateUser/AlreadyExists.failure.test.ts
+++ b/tests/handlers/users/UpdateUser/AlreadyExists.failure.test.ts
@@ -28,7 +28,7 @@ describe('Update User failure tests', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: new Date().toISOString()
@@ -41,7 +41,7 @@ describe('Update User failure tests', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'marydoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: new Date().toISOString()
@@ -82,7 +82,7 @@ describe('Update User failure tests', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: new Date().toISOString()
@@ -95,7 +95,7 @@ describe('Update User failure tests', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'marydoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: new Date().toISOString()

--- a/tests/handlers/users/UpdateUser/Success.test.ts
+++ b/tests/handlers/users/UpdateUser/Success.test.ts
@@ -29,7 +29,7 @@ describe('Update User handler E2E', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
-			isDeleted: false,
+			deletedAt: null,
 			kats: 0,
 			rank: 0,
 			createdAt: date
@@ -63,7 +63,6 @@ describe('Update User handler E2E', () => {
 				username: 'marydoe123',
 				email: 'marydoe@example.com',
 				isActive: true,
-				isDeleted: false,
 				createdAt: date
 			}
 		})


### PR DESCRIPTION
## Changes Made

This PR updates the users table by replacing the `isDeleted` column (boolean type) with `deletedAt` (Date type). The new column can hold a `null` value, allowing us to track when a user was soft deleted. This change improves the historical accuracy and provides better insights into user deletion events.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
<!-- - [x] New feature -->
 - [x] _**Breaking change**_ (The `isDeleted` field has been removed from JSON responses. Applications depending on this field will need to be updated to use the new `deletedAt` field instead.) 
 - [x] Documentation update 

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
