### PR TITLE
 Add restoredAt on users database table

### DIFF
--- a/src/db/user.schema.ts
+++ b/src/db/user.schema.ts
@@ -10,5 +10,6 @@ export const users = sqliteTable('users', {
 	rank: integer(),
 	isActive: integer({ mode: 'boolean' }).notNull().default(true),
 	createdAt: text().notNull(),
-	deletedAt: text({ length: 24 })
+	deletedAt: text({ length: 24 }),
+	restoredAt: text({ length: 24 })
 })

--- a/src/dtos/User.DTO.ts
+++ b/src/dtos/User.DTO.ts
@@ -9,4 +9,5 @@ export interface IUsersDTO {
 	isActive: boolean
 	createdAt: string
 	deletedAt?: string | null
+	restoredAt?: string | null
 }

--- a/src/entities/User.Entity.ts
+++ b/src/entities/User.Entity.ts
@@ -11,6 +11,7 @@ export class User {
 	public isActive!: boolean
 	public createdAt!: string
 	public deletedAt?: string | null
+	public restoredAt?: string | null
 
 	public constructor(props: Omit<User, 'id'>) {
 		Object.assign(this, props)

--- a/src/migrations/0003_migration.sql
+++ b/src/migrations/0003_migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `restoredAt` text(24);

--- a/src/migrations/meta/0003_snapshot.json
+++ b/src/migrations/meta/0003_snapshot.json
@@ -1,0 +1,107 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "4efaec5b-3ad4-42bb-a41a-8aef3f709709",
+	"prevId": "aa0f2471-df19-45cd-aad4-11c98861d014",
+	"tables": {
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"kats": {
+					"name": "kats",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isActive": {
+					"name": "isActive",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"restoredAt": {
+					"name": "restoredAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/migrations/meta/_journal.json
+++ b/src/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1737056672014,
 			"tag": "0002_migration",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1737073723111,
+			"tag": "0003_migration",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -123,12 +123,30 @@ export class UserRepository {
 		return updatedUser
 	}
 
-	public async delete(id: string): Promise<void> {
+	public async delete(id: string): Promise<User> {
 		await this.db
 			.update(users)
 			.set({
-				deletedAt: new Date().toISOString()
+				deletedAt: new Date().toISOString(),
+				isActive: false
 			})
 			.where(eq(users.id, id))
+
+		const user = await this.db
+			.select()
+			.from(users)
+			.where(eq(users.id, id))
+			.limit(1)
+
+		if (user.length === 0) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'User not found after update. Possible data inconsistency.'
+			})
+		}
+
+		const deletedUser = new User(user[0])
+
+		return deletedUser
 	}
 }

--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -43,17 +43,17 @@ export class UserRepository {
 			return null
 		}
 
-		const getUser = await this.db
+		const process = await this.db
 			.select()
 			.from(users)
 			.where(and(or(...includeConditions), ...excludeConditions))
 			.limit(1)
 
-		if (getUser.length === 0) {
+		if (process.length === 0) {
 			return null
 		}
 
-		const user = getUser.map((item) => {
+		const user = process.map((item) => {
 			return new User(item)
 		})
 
@@ -61,12 +61,12 @@ export class UserRepository {
 	}
 
 	public async create(data: User): Promise<User> {
-		const createdUser = await this.db.insert(users).values(data)
+		const process = await this.db.insert(users).values(data)
 
-		if (createdUser.error) {
+		if (process.error) {
 			throw new AppError({
 				name: 'Internal Server Error',
-				message: createdUser.error
+				message: process.error
 			})
 		}
 
@@ -83,11 +83,13 @@ export class UserRepository {
 			})
 		}
 
-		return user[0]
+		const createdUser = new User(user[0])
+
+		return createdUser
 	}
 
 	public async update(data: User): Promise<User> {
-		const updatedUser = await this.db
+		const process = await this.db
 			.update(users)
 			.set({
 				name: data.name,
@@ -96,10 +98,10 @@ export class UserRepository {
 			})
 			.where(eq(users.id, data.id))
 
-		if (updatedUser.error) {
+		if (process.error) {
 			throw new AppError({
 				name: 'Internal Server Error',
-				message: updatedUser.error
+				message: process.error
 			})
 		}
 
@@ -116,7 +118,9 @@ export class UserRepository {
 			})
 		}
 
-		return user[0]
+		const updatedUser = new User(user[0])
+
+		return updatedUser
 	}
 
 	public async delete(id: string): Promise<void> {

--- a/src/services/users/CreateUser/CreateUser.Service.ts
+++ b/src/services/users/CreateUser/CreateUser.Service.ts
@@ -31,6 +31,7 @@ export class CreateUserService {
 		user.rank = undefined
 		user.email = user.email === null ? undefined : user.email
 		user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
+		user.restoredAt = user.restoredAt === null ? undefined : user.restoredAt
 
 		return user
 	}

--- a/src/services/users/UpdateUser/UpdateUser.Service.ts
+++ b/src/services/users/UpdateUser/UpdateUser.Service.ts
@@ -24,6 +24,7 @@ export class UpdateUserService {
 		user.kats = undefined
 		user.rank = undefined
 		user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
+		user.restoredAt = user.restoredAt === null ? undefined : user.restoredAt
 
 		return user
 	}


### PR DESCRIPTION
## Changes Made

This PR introduces a new column, `restoredAt`, to the database. The column is of type `date` and will store the timestamp of when a soft-deleted user is restored. This enhancement allows tracking of user restoration events and provides better data consistency for soft-deletion workflows.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
- [x] New feature
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [ ] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
