### PR TITLE
Implement soft delete user endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,69 @@ Allows updating user data but prevents updates if the `username` or `email` alre
 
 </details>
 
+<details>
+ <summary><code>DELETE</code> <code><b>/users/{userId}</b></code> <code>Delete User</code></summary>
+ 
+#### Delete User
+Allows soft deletion for users. When using this endpoint, users are marked as deleted without permanently removing their data from the database. This approach helps maintain data integrity and prevents potential issues with foreign key constraints.
+
+#### Request 
+
+> #### Header Parameters 
+> | name         |  required | description                                                                                          |
+> |--------------|-----------|------------------------------------------------------------------------------------------------------|
+> | Content-Type |  yes      | Required for operations with a request body. The value is application/. Where the 'format' is 'json'.|
+> | X-CSRF-Token |  yes      | A CSRF token to protect against cross-site request forgery attacks. Must be included in the request.|
+
+> #### Path Parameters
+> | Name | Type   | Required | Description                          |
+> |------|--------|----------|--------------------------------------|
+> | id   | string | **yes**  | The unique identifier of the user.  |
+
+#### Response 
+
+> #### Sample Successful Response 
+>
+> Status Code: `201` <br>
+> application/json
+>```json
+>{
+>    "success": true,
+>    "message": "User deleted successfully!",
+>    "data": {
+>      "id": "01JEVAG858D9NP6A1NMTKXPRRA",
+>      "name": "John Doe",
+>      "username": "jhondoe123",
+>      "email": "john.doe@example.com",
+>      "kats": 0,
+>      "rank": 0,
+>      "isActive": true,
+>      "deletedAt": "2025-01-14T03:14:41.000Z",
+>      "createdAt": "2025-01-13T03:14:41.000Z"
+>    }
+>}
+>```
+
+
+> #### Response Schema
+> application/json
+>| Key         | Type     | Description                                      |
+>|-------------|----------|--------------------------------------------------|
+>| success     | boolean  | Indicates whether the request was successful.    |
+>| message     | string   | A message providing additional context.          |
+>| data        | object   | Contains user authentication details.            |
+>| data.id       | string   | Unique identifier for the user (ulid format).  |
+>| data.name     | string   | Name for the user.                             |
+>| data.email    | string   | Email for the user.                            |
+>| data.kats    | number   | Represents the amount of Legion community currency the user possesses.                            |
+>| data.rank    | number   | Indicates the user's rank within the Legion community.                            |
+>| data.isActive    | boolean   | Indicates if the user is currently active.                            |
+>| data.deletedAt    | string   | Date of the user was deleted.                            |
+>| data.createdAt    | string   | Date of the user was created (ISO 8601 format).    |
+
+
+</details>
+
 
 ------------------------------------------------------------------------------------------
 

--- a/src/dtos/Id.DTO.ts
+++ b/src/dtos/Id.DTO.ts
@@ -1,0 +1,3 @@
+export interface IIdDTO {
+	id: string
+}

--- a/src/handlers/error/Errors.Handler.ts
+++ b/src/handlers/error/Errors.Handler.ts
@@ -28,6 +28,16 @@ export const errorsHandler = (
 		)
 	}
 
+	if (error.stack?.includes('csrf')) {
+		return c.json(
+			{
+				success: false,
+				message: 'Access denied.'
+			},
+			403
+		)
+	}
+
 	return c.json(
 		{
 			success: false,

--- a/src/handlers/users/DeleteUser/DeleteUser.Handler.ts
+++ b/src/handlers/users/DeleteUser/DeleteUser.Handler.ts
@@ -1,0 +1,31 @@
+import type { User } from '@src/entities/User.Entity'
+import { UserRepository } from '@src/repositories/users/User.Repository'
+import { DeleteUserService } from '@src/services/users/DeleteUser/DeleteUser.Service'
+import type { Presenter } from '@src/types/presenter'
+import { factory } from '@src/utils/factory'
+import type { TypedResponse } from 'hono'
+import { logger } from 'hono/logger'
+import type { StatusCode } from 'hono/utils/http-status'
+
+export const DeleteUserHandler = factory.createHandlers(
+	logger(),
+	async (c): Promise<TypedResponse<Presenter<User>, StatusCode>> => {
+		const usersRepository = new UserRepository(c.env.DB)
+		const deleteUserService = new DeleteUserService(usersRepository)
+
+		const id = c.req.param('id')
+
+		const data = { id }
+
+		const user = await deleteUserService.execute(data)
+
+		return c.json(
+			{
+				success: true,
+				message: 'User deleted successfully',
+				data: user
+			},
+			200
+		)
+	}
+)

--- a/src/routers/users.router.ts
+++ b/src/routers/users.router.ts
@@ -1,4 +1,5 @@
 import { CreateUserHandler } from '@src/handlers/users/CreateUser/CreateUser.Handler'
+import { DeleteUserHandler } from '@src/handlers/users/DeleteUser/DeleteUser.Handler'
 import { UpdateUserHandler } from '@src/handlers/users/UpdateUser/UpdateUser.Handler'
 import { Hono } from 'hono'
 
@@ -6,5 +7,6 @@ const usersRouters = new Hono()
 
 usersRouters.post('/users', ...CreateUserHandler)
 usersRouters.put('/users/:id', ...UpdateUserHandler)
+usersRouters.delete('/users/:id', ...DeleteUserHandler)
 
 export default usersRouters

--- a/src/validations/id/Id.Validation.ts
+++ b/src/validations/id/Id.Validation.ts
@@ -1,0 +1,10 @@
+import { validator } from '@src/lib/validator'
+
+export const idSchema = validator.schema(
+	{
+		id: validator.string().ulid()
+	},
+	{
+		strict: true
+	}
+)

--- a/tests/handlers/users/DeleteUser/Csrf.failure.test.ts
+++ b/tests/handlers/users/DeleteUser/Csrf.failure.test.ts
@@ -1,0 +1,35 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Delete User Input CSRF - E2E', () => {
+	const db = drizzle(env.DB)
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when content-type is not application/json', async () => {
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'DELETE'
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(403)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Access denied.'
+		})
+	})
+})

--- a/tests/handlers/users/DeleteUser/IsDeleted.failure.test.ts
+++ b/tests/handlers/users/DeleteUser/IsDeleted.failure.test.ts
@@ -1,0 +1,95 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Delete User handler isDeleted - E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail if id not found', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const res = await app.request(
+			'/users/01JHT92033GDR5JBP49R4QC4C5',
+			{
+				method: 'DELETE',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(404)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'User not founded!',
+			cause: {
+				id: '01JHT92033GDR5JBP49R4QC4C5'
+			}
+		})
+	})
+
+	test('should fail if user already deleted and not restored', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: '2025-01-17T14:04:16.234Z',
+			kats: 0,
+			rank: 0,
+			restoredAt: null,
+			createdAt: date
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'DELETE',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(404)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'This user has been deleted!',
+			cause: {
+				id: '01JHBDWAXFPAKAFK38E1MAM01W'
+			}
+		})
+	})
+})

--- a/tests/handlers/users/DeleteUser/Success.test.ts
+++ b/tests/handlers/users/DeleteUser/Success.test.ts
@@ -1,0 +1,73 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Delete User handler E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should delete user successfully', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W',
+			{
+				method: 'DELETE',
+				headers
+			},
+			env
+		)
+
+		const user = await db
+			.select()
+			.from(users)
+			.where(eq(users.id, '01JHBDWAXFPAKAFK38E1MAM01W'))
+			.limit(1)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'User deleted successfully',
+			data: {
+				id: '01JHBDWAXFPAKAFK38E1MAM01W',
+				name: 'John Doe',
+				username: 'johndoe123',
+				email: 'johndoe@example.com',
+				kats: 0,
+				rank: 0,
+				isActive: false,
+				deletedAt: user[0].deletedAt,
+				createdAt: date
+			}
+		})
+	})
+})

--- a/tests/handlers/users/DeleteUser/Validation.failure.test.ts
+++ b/tests/handlers/users/DeleteUser/Validation.failure.test.ts
@@ -1,0 +1,45 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Delete User Input Validation - E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when id is not ulid format', async () => {
+		const res = await app.request(
+			'/users/12345',
+			{
+				method: 'DELETE',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'id',
+				cause: 'is not ulid'
+			}
+		})
+	})
+})


### PR DESCRIPTION
## Changes Made

This PR introduces a soft delete endpoint, allowing users to be marked as deleted without permanently removing their data from the database. This approach helps maintain data integrity and prevents potential issues caused by the loss of critical user information. When a user is soft deleted, the `deletedAt` field is populated with the deletion timestamp, and the `isActive` is set to false to indicate the user is no longer active.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
 - [x] Documentation update

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
