### PR TITLE
Add equals() validation to validator

### DIFF
--- a/src/lib/validator/String.Validation.ts
+++ b/src/lib/validator/String.Validation.ts
@@ -128,4 +128,20 @@ export class StringValidation extends ValidationBase {
 		})
 		return this
 	}
+
+	public equals(equals: string): this {
+		this.addValidator((value: string) => {
+			if (value !== equals) {
+				return {
+					success: false,
+					failedValidator: 'equals'
+				}
+			}
+
+			return {
+				success: true
+			}
+		})
+		return this
+	}
 }

--- a/tests/lib/validator/Strings.test.ts
+++ b/tests/lib/validator/Strings.test.ts
@@ -232,4 +232,25 @@ describe('Validator Library', () => {
 			field: 'data'
 		})
 	})
+
+	test('validates equals string format', () => {
+		const schema = validator.schema({
+			data: validator.string().equals('equals-data')
+		})
+
+		const validData = { data: 'equals-data' }
+		const validResult = schema.check(validData)
+
+		const invalidData = { data: '33-04-1990' }
+		const invalidResult = schema.check(invalidData)
+
+		expect(validResult).toStrictEqual({
+			success: true
+		})
+		expect(invalidResult).toStrictEqual({
+			success: false,
+			failedValidator: 'equals',
+			field: 'data'
+		})
+	})
 })


### PR DESCRIPTION
## Changes Made

This PR introduces a new equals() validator for the validator library.
The equals() validator is specifically designed for the string() type and allows you to enforce that a string field must match an exact value. By using this validation, you can ensure that the field adheres to a predefined value.

Usage example:

```typescript
import { validator } from '@src/lib/validator'

const schema = validator.schema({
    data: validator.string().equals('equals-data')
});

const validData = { data: 'equals-data' };
const validResult = schema.check(validData);

const invalidData = { data: '33-04-1990' };
const invalidResult = schema.check(invalidData);
```


## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
<!-- - [x] Breaking change (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.