### PR TITLE
Add NaN check to number() validation

### DIFF
--- a/src/lib/validator/Number.Validation.ts
+++ b/src/lib/validator/Number.Validation.ts
@@ -4,7 +4,10 @@ export class NumberValidation extends ValidationBase {
 	public constructor() {
 		super()
 		this.addValidator((value) => {
-			return { success: typeof value === 'number', failedValidator: 'number' }
+			return {
+				success: !Number.isNaN(value) && typeof value === 'number',
+				failedValidator: 'number'
+			}
 		})
 	}
 

--- a/tests/lib/validator/Number.test.ts
+++ b/tests/lib/validator/Number.test.ts
@@ -83,4 +83,25 @@ describe('Validator Library', () => {
 			success: true
 		})
 	})
+
+	test('should fail with NaN data', () => {
+		const schema = validator.schema({
+			data: validator.number()
+		})
+
+		const validData = { data: 3 }
+		const validResult = schema.check(validData)
+
+		const nullData = {}
+		const nullResult = schema.check(nullData)
+
+		expect(validResult).toStrictEqual({
+			success: true
+		})
+		expect(nullResult).toStrictEqual({
+			success: false,
+			failedValidator: 'nullable',
+			field: 'data'
+		})
+	})
 })


### PR DESCRIPTION
## Changes Made

This PR adds a `NaN` (Not-a-Number) check to the `.number()` validation, ensuring that `NaN` values are rejected during the validation process. This enhancement guarantees that only valid numerical values are accepted, improving the reliability of the validator library.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

 - [x] Bug fix
<!-- - [x] New feature -->
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
