### PR TITLE
Implement paginated user list endpoint with support for soft-deleted users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,98 @@ Lists API endpoints for easier integration with your application. You can call t
 ### Users
 
 <details>
+ <summary><code>GET</code> <code><b>/users?page={number}</b></code> <code>List Users</code></summary>
+ 
+#### List Users
+Retrieves a paginated list of users, with 20 users per page, including detailed information for each. If the user is marked as deleted, the response return deleted status without exposing sensitive or unnecessary data.
+
+#### Request 
+
+> #### Header Parameters 
+> | name         |  required | description                                                                                          |
+> |--------------|-----------|------------------------------------------------------------------------------------------------------|
+> | Content-Type |  yes      | Required for operations with a request body. The value is application/. Where the 'format' is 'json'.|
+> | X-CSRF-Token |  yes      | A CSRF token to protect against cross-site request forgery attacks. Must be included in the request.|
+
+> #### Query Parameters
+> | Name | Type   | Required | Description                          |
+> |------|--------|----------|--------------------------------------|
+> | page   | string | **yes**  | The page number to retrieve.  |
+> | includeDeleted   | string | **no**  | If set to `true`, includes data for soft-deleted users in the response. By default, only active users are retrieved.  |
+
+#### Response 
+
+> #### Sample Successful Response 
+>
+> Status Code: `200` <br>
+> application/json
+>```json
+>{
+>    "success": true,
+>    "message": "Users list retrieved successfully!",
+>    "data": {
+>      "users": [
+>           {
+>               "id": "01JJ02AHX4NEFDRH5PT5KQX5MT",
+>               "name": "Elaine Windler",
+>               "username": "Jaylon.Stamm22",
+>               "email": "Sherwood50@gmail.com",
+>               "kats": 0,
+>               "rank": null,
+>               "isActive": true,
+>               "createdAt": "2025-01-19T19:58:34.404Z"
+>           },
+>           {
+>               "id": "01JJ0W0VM4F6DFDZWYD6P10E21",
+>               "name": "Miss Luz Brakus",
+>               "username": "Verlie.Dietrich66",
+>               "email": "Howell.Graham61@hotmail.com",
+>               "kats": 0,
+>               "rank": null,
+>               "isActive": true,
+>               "createdAt": "2025-01-20T03:27:39.652Z"
+>           },
+>           ...
+>       ],
+>       "pagination": {
+>           "totalPages": 1,
+>           "totalItems": 3,
+>           "isLastPage": true
+>       }
+>    }
+>}
+>```
+
+
+> #### Response Schema
+> application/json
+>| Key         | Type     | Description                                      |
+>|-------------|----------|--------------------------------------------------|
+>| success     | boolean  | Indicates whether the request was successful.    |
+>| message     | string   | A message providing additional context.          |
+>| data        | object   | Contains the list of users and pagination details.            |
+>| data.users[]                | array    | An array of user objects.                                                   |
+>| data.users[].id             | string   | Unique identifier for the user (ULID format).                               |
+>| data.users[].name           | string   | The user's full name.                                                       |
+>| data.users[].username       | string   | The user's username.                                                       |
+>| data.users[].email          | string   | The user's email address.                                                   |
+>| data.users[].kats           | number   | Represents the amount of Legion community currency the user possesses.      |
+>| data.users[].rank           | number   | The user's rank within the Legion community (null if unranked).             |
+>| data.users[].isActive       | boolean  | Indicates whether the user is active.                                       |
+>| data.users[].deletedAt      | string   | The date the user was deleted, or null if active.                           |
+>| data.users[].restoredAt      | string   | The date the user was restored.                           |
+>| data.users[].createdAt      | string   | Date when the user was created (ISO 8601 format).                           |
+>| data.pagination           | object   | Pagination information for the result set.                                 |
+>| data.pagination.totalPages| number   | Total number of pages available.                                            |
+>| data.pagination.totalItems| number   | Total number of users available.                                           |
+>| data.pagination.isLastPage| boolean  | Indicates whether the current page is the last one.                         |
+
+
+
+</details>
+
+
+<details>
  <summary><code>GET</code> <code><b>/users/{userId}</b></code> <code>Get User</code></summary>
  
 #### Get User
@@ -56,12 +148,12 @@ Fetches detailed information about a specific user using the provided `id`. If t
 
 > #### Sample Successful Response 
 >
-> Status Code: `201` <br>
+> Status Code: `200` <br>
 > application/json
 >```json
 >{
 >    "success": true,
->    "message": "User deleted successfully!",
+>    "message": "User retrieved successfully!",
 >    "data": {
 >      "id": "01JEVAG858D9NP6A1NMTKXPRRA",
 >      "name": "John Doe",
@@ -186,12 +278,12 @@ Allows updating user data but prevents updates if the `username` or `email` alre
 
 > #### Sample Successful Response 
 >
-> Status Code: `201` <br>
+> Status Code: `200` <br>
 > application/json
 >```json
 >{
 >    "success": true,
->    "message": "User created successfully!",
+>    "message": "User updated successfully!",
 >    "data": {
 >      "id": "01JEVAG858D9NP6A1NMTKXPRRA",
 >      "name": "John Doe",
@@ -243,7 +335,7 @@ Allows soft deletion for users. When using this endpoint, users are marked as de
 
 > #### Sample Successful Response 
 >
-> Status Code: `201` <br>
+> Status Code: `200` <br>
 > application/json
 >```json
 >{

--- a/src/dtos/List.DTO.ts
+++ b/src/dtos/List.DTO.ts
@@ -1,0 +1,13 @@
+export interface IListDTO {
+	page: number
+	includeDeleted: string | undefined
+}
+
+export interface IListResultDTO<T> {
+	users: T[]
+	pagination: {
+		totalPages: number
+		totalItems: number
+		isLastPage: boolean
+	}
+}

--- a/src/dtos/Pagination.DTO.ts
+++ b/src/dtos/Pagination.DTO.ts
@@ -1,0 +1,10 @@
+export interface IPaginationParamsDTO {
+	limit: number
+	page: number
+	includeDeleted?: boolean
+}
+
+export interface PaginatedResult<T> {
+	totalItems: number
+	items: T[]
+}

--- a/src/handlers/users/ListUsers/ListUsers.Handler.ts
+++ b/src/handlers/users/ListUsers/ListUsers.Handler.ts
@@ -1,0 +1,36 @@
+import type { IListDTO, IListResultDTO } from '@src/dtos/List.DTO'
+import type { User } from '@src/entities/User.Entity'
+import { UserRepository } from '@src/repositories/users/User.Repository'
+import { ListUsersService } from '@src/services/users/ListUsers/ListUsers.Service'
+import type { Presenter } from '@src/types/presenter'
+import { factory } from '@src/utils/factory'
+import type { TypedResponse } from 'hono'
+import { logger } from 'hono/logger'
+import type { StatusCode } from 'hono/utils/http-status'
+
+export const ListUsersHandler = factory.createHandlers(
+	logger(),
+	async (
+		c
+	): Promise<TypedResponse<Presenter<IListResultDTO<User>>, StatusCode>> => {
+		const usersRepository = new UserRepository(c.env.DB)
+		const listUsersService = new ListUsersService(usersRepository)
+
+		const page = Number.parseInt(c.req.query('page') ?? '')
+
+		const includeDeleted = c.req.query('includeDeleted')
+
+		const data: IListDTO = { page, includeDeleted }
+
+		const users = await listUsersService.execute(data)
+
+		return c.json(
+			{
+				success: true,
+				message: 'Users list retrieved successfully',
+				data: users
+			},
+			200
+		)
+	}
+)

--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -35,18 +35,16 @@ export class UserRepository {
 			userQuery = this.db.select().from(users).limit(data.limit).offset(offset)
 		}
 
-		const userRecords = await userQuery
-
 		let countQuery = this.db
 			.select({ count: count() })
 			.from(users)
-			.offset(offset)
 			.where(isNull(users.deletedAt))
 
 		if (data.includeDeleted) {
-			countQuery = this.db.select({ count: count() }).from(users).offset(offset)
+			countQuery = this.db.select({ count: count() }).from(users)
 		}
 
+		const userRecords = await userQuery
 		const totalUsers = await countQuery
 
 		const usersList = userRecords.map((item) => {

--- a/src/routers/users.router.ts
+++ b/src/routers/users.router.ts
@@ -1,12 +1,14 @@
 import { CreateUserHandler } from '@src/handlers/users/CreateUser/CreateUser.Handler'
 import { DeleteUserHandler } from '@src/handlers/users/DeleteUser/DeleteUser.Handler'
 import { GetUserByIdHandler } from '@src/handlers/users/GetUserById/GetUserById.Handler'
+import { ListUsersHandler } from '@src/handlers/users/ListUsers/ListUsers.Handler'
 import { UpdateUserHandler } from '@src/handlers/users/UpdateUser/UpdateUser.Handler'
 import { Hono } from 'hono'
 
 const usersRouters = new Hono()
 
 usersRouters.get('/users/:id', ...GetUserByIdHandler)
+usersRouters.get('/users', ...ListUsersHandler)
 usersRouters.post('/users', ...CreateUserHandler)
 usersRouters.put('/users/:id', ...UpdateUserHandler)
 usersRouters.delete('/users/:id', ...DeleteUserHandler)

--- a/src/services/users/ListUsers/ListUsers.Service.ts
+++ b/src/services/users/ListUsers/ListUsers.Service.ts
@@ -1,0 +1,63 @@
+import type { IListDTO, IListResultDTO } from '@src/dtos/List.DTO'
+import type { User } from '@src/entities/User.Entity'
+import { AppError } from '@src/errors/AppErrors.Error'
+import type { UserRepository } from '@src/repositories/users/User.Repository'
+import { listUsersSchema } from '@src/validations/users/ListUsers.Validation'
+
+export class ListUsersService {
+	public constructor(private readonly userRepository: UserRepository) {}
+
+	public async execute(data: IListDTO): Promise<IListResultDTO<User>> {
+		this.validation(data)
+
+		const users = await this.userRepository.findAll({
+			limit: 20,
+			page: data.page,
+			includeDeleted: data.includeDeleted ? true : undefined
+		})
+
+		if (users.totalItems === 0) {
+			throw new AppError({
+				name: 'Not Found',
+				message: 'No users found!'
+			})
+		}
+
+		const totalPages = Math.ceil(users.totalItems / 20)
+
+		return {
+			users: this.sanitizeUser(users.items),
+			pagination: {
+				totalPages,
+				totalItems: users.totalItems,
+				isLastPage: data.page >= totalPages
+			}
+		}
+	}
+
+	private sanitizeUser(users: User[]): User[] {
+		const sanitizedUsers = users.map((user) => {
+			user.password = undefined
+			user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
+			user.restoredAt = user.restoredAt === null ? undefined : user.restoredAt
+			return user
+		})
+
+		return sanitizedUsers
+	}
+
+	private validation(data: IListDTO): void {
+		const isValidData = listUsersSchema.check(data)
+
+		if (!isValidData.success) {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Validation failed',
+				cause: {
+					field: isValidData.field,
+					cause: `is not ${isValidData.failedValidator}`
+				}
+			})
+		}
+	}
+}

--- a/src/validations/users/ListUsers.Validation.ts
+++ b/src/validations/users/ListUsers.Validation.ts
@@ -1,0 +1,11 @@
+import { validator } from '@src/lib/validator'
+
+export const listUsersSchema = validator.schema(
+	{
+		page: validator.number(),
+		includeDeleted: validator.string().equals('true').nullable()
+	},
+	{
+		strict: true
+	}
+)

--- a/tests/handlers/users/ListUsers/NotFound.failure.test.ts
+++ b/tests/handlers/users/ListUsers/NotFound.failure.test.ts
@@ -1,0 +1,41 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('List Users failure tests', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when theres no users in database - E2E', async () => {
+		const res = await app.request(
+			'/users?page=1',
+			{
+				method: 'GET',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(404)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'No users found!'
+		})
+	})
+})

--- a/tests/handlers/users/ListUsers/Success.test.ts
+++ b/tests/handlers/users/ListUsers/Success.test.ts
@@ -1,0 +1,228 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('List Users handler E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should retrieved users list successfully', async () => {
+		const date = new Date().toISOString()
+
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		await db.insert(users).values({
+			id: '01JJ0SF7NJGX8THM5J59WY845C',
+			name: 'Mary Doe',
+			username: 'marydoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'marydoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const res = await app.request(
+			'/users?page=1',
+			{
+				method: 'GET',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'Users list retrieved successfully',
+			data: {
+				users: [
+					{
+						id: '01JHBDWAXFPAKAFK38E1MAM01W',
+						name: 'John Doe',
+						username: 'johndoe123',
+						email: 'johndoe@example.com',
+						kats: 0,
+						rank: 0,
+						isActive: true,
+						createdAt: date
+					},
+					{
+						id: '01JJ0SF7NJGX8THM5J59WY845C',
+						name: 'Mary Doe',
+						username: 'marydoe123',
+						email: 'marydoe@example.com',
+						kats: 0,
+						rank: 0,
+						isActive: true,
+						createdAt: date
+					}
+				],
+				pagination: {
+					isLastPage: true,
+					totalItems: 2,
+					totalPages: 1
+				}
+			}
+		})
+	})
+
+	test('should retrieved including soft deleted users list successfully ', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: date,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		await db.insert(users).values({
+			id: '01JJ0SF7NJGX8THM5J59WY845C',
+			name: 'Mary Doe',
+			username: 'marydoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'marydoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const res = await app.request(
+			'/users?page=1&includeDeleted=true',
+			{
+				method: 'GET',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'Users list retrieved successfully',
+			data: {
+				users: [
+					{
+						id: '01JHBDWAXFPAKAFK38E1MAM01W',
+						name: 'John Doe',
+						username: 'johndoe123',
+						email: 'johndoe@example.com',
+						kats: 0,
+						rank: 0,
+						deletedAt: date,
+						isActive: true,
+						createdAt: date
+					},
+					{
+						id: '01JJ0SF7NJGX8THM5J59WY845C',
+						name: 'Mary Doe',
+						username: 'marydoe123',
+						email: 'marydoe@example.com',
+						kats: 0,
+						rank: 0,
+						isActive: true,
+						createdAt: date
+					}
+				],
+				pagination: {
+					isLastPage: true,
+					totalItems: 2,
+					totalPages: 1
+				}
+			}
+		})
+	})
+
+	test('should retrieved a empty users list page successfully ', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: date,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		await db.insert(users).values({
+			id: '01JJ0SF7NJGX8THM5J59WY845C',
+			name: 'Mary Doe',
+			username: 'marydoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'marydoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const res = await app.request(
+			'/users?page=2&includeDeleted=true',
+			{
+				method: 'GET',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'Users list retrieved successfully',
+			data: {
+				users: [],
+				pagination: {
+					isLastPage: true,
+					totalItems: 2,
+					totalPages: 1
+				}
+			}
+		})
+	})
+})

--- a/tests/handlers/users/ListUsers/Validation.failure.test.ts
+++ b/tests/handlers/users/ListUsers/Validation.failure.test.ts
@@ -1,0 +1,68 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Get User List Input Validation - E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when page is missing', async () => {
+		const res = await app.request(
+			'/users',
+			{
+				method: 'GET',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'page',
+				cause: 'is not number'
+			}
+		})
+	})
+
+	test('should fail when includeDeleted query parameter is not equals true', async () => {
+		const res = await app.request(
+			'/users?page=1&includeDeleted=false',
+			{
+				method: 'GET',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				field: 'includeDeleted',
+				cause: 'is not equals'
+			}
+		})
+	})
+})


### PR DESCRIPTION
## Changes Made

This PR introduces an endpoint for retrieving a paginated list of users, with 20 users per page, optimizing performance by limiting the number of users returned per request, ensuring a more efficient and scalable API. The pagination details, such as the total number of pages and whether the current page is the last one. The response provides detailed information about each user, without exposing sensitive data.

Additionally, the endpoint supports an optional query parameter `includeDeleted=true`, which allows for retrieving soft-deleted users, improving the ability to manage and audit users. By default, only active users are returned unless this parameter is explicitly included.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
 - [x] Documentation update 

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
