### PR TITLE
Enforce "At Least One Field" Validation in Strict Mode

### DIFF
--- a/src/lib/validator/Schema.Validation.ts
+++ b/src/lib/validator/Schema.Validation.ts
@@ -17,13 +17,21 @@ export class SchemaValidation<T extends Record<string, unknown>> {
 
 	public check(data: Partial<T>): ValidationResult {
 		if (this.strict) {
-			const extraKeys = Object.keys(data).filter((key) => !(key in this.schema))
+			const keys = Object.keys(data)
+			const extraKeys = keys.filter((key) => !(key in this.schema))
 
 			if (extraKeys.length > 0) {
 				return {
 					success: false,
 					failedValidator: 'unknownPropertiesDetected',
 					field: extraKeys
+				}
+			}
+
+			if (keys.length === 0) {
+				return {
+					success: false,
+					failedValidator: 'AtLeastOneFieldRequired'
 				}
 			}
 		}

--- a/tests/lib/validator/Strict.test.ts
+++ b/tests/lib/validator/Strict.test.ts
@@ -27,4 +27,29 @@ describe('Validator Library', () => {
 			field: ['invalidField']
 		})
 	})
+
+	test('should fail if check empty object', () => {
+		const schema = validator.schema(
+			{
+				data: validator.boolean().nullable()
+			},
+			{
+				strict: true
+			}
+		)
+
+		const validData = { data: true }
+		const validResult = schema.check(validData)
+
+		const invalidData = {}
+		const invalidResult = schema.check(invalidData)
+
+		expect(validResult).toStrictEqual({
+			success: true
+		})
+		expect(invalidResult).toStrictEqual({
+			success: false,
+			failedValidator: 'AtLeastOneFieldRequired'
+		})
+	})
 })


### PR DESCRIPTION
## Changes Made

This pull request introduces a validation enhancement for the `strict` mode in the `validator`. With this update, when `strict` is enabled, the validator now enforces that at least one field from the `schema` must be provided. This ensures better alignment with the intended schema structure and prevents incomplete or invalid inputs.

By adding this rule, the validator improves its ability to handle edge cases where empty or irrelevant payloads might otherwise pass unnoticed. This change strengthens schema integrity and enhances data validation robustness.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
