### PR TITLE
Refactor findOneByOr to return a single object instead of an array

### DIFF
--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -59,7 +59,7 @@ export class UserRepository {
 		email,
 		username,
 		andNot
-	}: FindByParams): Promise<User[] | null> {
+	}: FindByParams): Promise<User | null> {
 		const includeConditions = []
 		const excludeConditions = []
 
@@ -96,7 +96,7 @@ export class UserRepository {
 			return new User(item)
 		})
 
-		return user
+		return user[0]
 	}
 
 	public async create(data: User): Promise<User> {

--- a/src/services/users/CreateUser/CreateUser.Service.ts
+++ b/src/services/users/CreateUser/CreateUser.Service.ts
@@ -43,12 +43,12 @@ export class CreateUserService {
 			username: user.username
 		})
 
-		if (existingUser && existingUser.length !== 0) {
+		if (existingUser) {
 			let conflictField: 'username' | 'email' | 'id'
 
-			if (existingUser[0].username === user.username) {
+			if (existingUser.username === user.username) {
 				conflictField = 'username'
-			} else if (existingUser[0].email === user.email) {
+			} else if (existingUser.email === user.email) {
 				conflictField = 'email'
 			} else {
 				conflictField = 'id'
@@ -58,7 +58,7 @@ export class CreateUserService {
 				name: 'Conflict',
 				message: 'This user already exists',
 				cause: {
-					[conflictField]: existingUser[0][conflictField]
+					[conflictField]: existingUser[conflictField]
 				}
 			})
 		}

--- a/src/services/users/DeleteUser/DeleteUser.Service.ts
+++ b/src/services/users/DeleteUser/DeleteUser.Service.ts
@@ -39,11 +39,7 @@ export class DeleteUserService {
 			})
 		}
 
-		if (
-			existingUser.length !== 0 &&
-			existingUser[0].deletedAt &&
-			!existingUser[0].restoredAt
-		) {
+		if (existingUser.deletedAt && !existingUser.restoredAt) {
 			throw new AppError({
 				name: 'Not Found',
 				message: 'This user has been deleted!',

--- a/src/services/users/GetUserById/GetUserById.Service.ts
+++ b/src/services/users/GetUserById/GetUserById.Service.ts
@@ -22,7 +22,7 @@ export class GetUserByIdService {
 			})
 		}
 
-		if (user[0].deletedAt && !user[0].restoredAt && !data.includeDeleted) {
+		if (user.deletedAt && !user.restoredAt && !data.includeDeleted) {
 			throw new AppError({
 				name: 'Not Found',
 				message: 'User has been deleted!',
@@ -32,7 +32,7 @@ export class GetUserByIdService {
 			})
 		}
 
-		return this.sanitizeUser(user[0])
+		return this.sanitizeUser(user)
 	}
 
 	private sanitizeUser(user: User): User {

--- a/src/services/users/UpdateUser/UpdateUser.Service.ts
+++ b/src/services/users/UpdateUser/UpdateUser.Service.ts
@@ -42,7 +42,7 @@ export class UpdateUserService {
 			})
 		}
 
-		return user[0]
+		return user
 	}
 
 	private async checkForConflict(user: User): Promise<void> {
@@ -54,15 +54,15 @@ export class UpdateUserService {
 			}
 		})
 
-		if (existingUser && existingUser.length !== 0) {
+		if (existingUser) {
 			const conflictField =
-				existingUser[0].username === user.username ? 'username' : 'email'
+				existingUser.username === user.username ? 'username' : 'email'
 
 			throw new AppError({
 				name: 'Conflict',
 				message: 'This user already exists',
 				cause: {
-					[conflictField]: existingUser[0][conflictField]
+					[conflictField]: existingUser[conflictField]
 				}
 			})
 		}


### PR DESCRIPTION
## Changes Made

This PR refactors the `findOneByOr` method in the `UserRepository` to return a single `User` object instead of an array of users. This simplifies the handling of verification for the method's results, reducing unnecessary checks and improving code clarity

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

- [x] Refactor
<!-- - [x] Bug fix -->
<!-- - [x] New feature -->
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [ ] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
