### PR TITLE
Implement JWT authentication with email/username and password

### DIFF
--- a/src/dtos/Auth.DTO.ts
+++ b/src/dtos/Auth.DTO.ts
@@ -1,0 +1,17 @@
+export type IAuthPasswordDTO = {
+	email?: string
+	password: string
+	username?: string
+} & ({ email: string } | { username: string })
+
+export interface IAuthReturnDTO {
+	id: string
+	name: string
+	username: string
+	email?: string
+	token: {
+		accessToken: string
+		refreshToken: string
+		expiresIn: number
+	}
+}

--- a/src/handlers/auth/users/UserAuth.Handler.ts
+++ b/src/handlers/auth/users/UserAuth.Handler.ts
@@ -1,0 +1,35 @@
+import type { IAuthReturnDTO } from '@src/dtos/Auth.DTO'
+import { AppError } from '@src/errors/AppErrors.Error'
+import { UserRepository } from '@src/repositories/users/User.Repository'
+import { UserAuthService } from '@src/services/auth/userAuth/UserAuth.Service'
+import type { Presenter } from '@src/types/presenter'
+import { factory } from '@src/utils/factory'
+import type { TypedResponse } from 'hono'
+import { logger } from 'hono/logger'
+import type { StatusCode } from 'hono/utils/http-status'
+
+export const UserAuthHandler = factory.createHandlers(
+	logger(),
+	async (c): Promise<TypedResponse<Presenter<IAuthReturnDTO>, StatusCode>> => {
+		const usersRepository = new UserRepository(c.env.DB)
+		const userAuthService = new UserAuthService(usersRepository, c.env)
+
+		const data = await c.req.json().catch(() => {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Invalid JSON format in request body'
+			})
+		})
+
+		const user = await userAuthService.execute(data)
+
+		return c.json(
+			{
+				success: true,
+				message: 'User authenticated successfully',
+				data: user
+			},
+			200
+		)
+	}
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { csrf } from 'hono/csrf'
 import { secureHeaders } from 'hono/secure-headers'
 import { errorsHandler } from './handlers/error/Errors.Handler'
+import authRouters from './routers/auth.router'
 import usersRouters from './routers/users.router'
 
 const app = new Hono()
@@ -11,6 +12,7 @@ app.use(csrf({ origin: process.env.LEGION_WEBSITE }))
 app.use(secureHeaders())
 
 app.route('/', usersRouters)
+app.route('/', authRouters)
 
 app.onError(errorsHandler)
 

--- a/src/routers/auth.router.ts
+++ b/src/routers/auth.router.ts
@@ -1,0 +1,8 @@
+import { UserAuthHandler } from '@src/handlers/auth/users/UserAuth.Handler'
+import { Hono } from 'hono'
+
+const authRouters = new Hono()
+
+authRouters.post('/users/login', ...UserAuthHandler)
+
+export default authRouters

--- a/src/services/auth/userAuth/UserAuth.Service.ts
+++ b/src/services/auth/userAuth/UserAuth.Service.ts
@@ -1,0 +1,145 @@
+import type { IAuthPasswordDTO, IAuthReturnDTO } from '@src/dtos/Auth.DTO'
+import type { User } from '@src/entities/User.Entity'
+import { AppError } from '@src/errors/AppErrors.Error'
+import type { UserRepository } from '@src/repositories/users/User.Repository'
+import type { Secrets } from '@src/types/envVariables'
+import { authSchema } from '@src/validations/users/Auth.Validation'
+import bcrypt from 'bcryptjs'
+import { sign } from 'hono/jwt'
+
+export class UserAuthService {
+	public constructor(
+		private readonly userRepository: UserRepository,
+		private readonly env: Secrets
+	) {}
+
+	public async execute(data: IAuthPasswordDTO): Promise<IAuthReturnDTO> {
+		this.validation(data)
+
+		const queryUser = await this.userRepository.findOneByOr({
+			email: data.email,
+			username: data.username,
+			andNot: {}
+		})
+		const user = this.validateUserStatus(queryUser)
+
+		await this.validatePassword(data.password, user.password)
+
+		const token = await this.generateToken(user)
+
+		return {
+			id: user.id,
+			name: user.name,
+			username: user.username,
+			email: user.email ? user.email : undefined,
+			token: {
+				accessToken: token.accessToken,
+				refreshToken: token.refreshToken,
+				expiresIn: token.accessTokenExp
+			}
+		}
+	}
+
+	private async validatePassword(
+		inputPassword: string,
+		storedPassword?: string | null
+	): Promise<void> {
+		if (!storedPassword) {
+			throw new AppError({
+				name: 'Unprocessable Entity',
+				message: 'Unable to complete authentication.'
+			})
+		}
+
+		const isValid = await bcrypt.compare(inputPassword, storedPassword)
+
+		if (!isValid) {
+			throw new AppError({
+				name: 'Unauthorized',
+				message: 'Access Denied!'
+			})
+		}
+	}
+
+	private validateUserStatus(user: User | null): User {
+		if (!user) {
+			throw new AppError({
+				name: 'Not Found',
+				message: 'User not founded!'
+			})
+		}
+
+		if (user.deletedAt && !user.restoredAt) {
+			throw new AppError({
+				name: 'Not Found',
+				message: 'User has been deleted!'
+			})
+		}
+
+		if (!user.isActive) {
+			throw new AppError({
+				name: 'Not Found',
+				message: 'User is inactive!'
+			})
+		}
+
+		return user
+	}
+
+	private async generateToken(user: User): Promise<{
+		accessToken: string
+		refreshToken: string
+		accessTokenExp: number
+	}> {
+		const payloadAccessToken = {
+			id: user.id,
+			name: user.name,
+			username: user.username,
+			iat: Math.floor(Date.now() / 1000),
+			exp: Math.floor(Date.now() / 1000) + 60 * 60
+		}
+
+		const payloadRefreshToken = {
+			id: user.id,
+			iat: Math.floor(Date.now() / 1000),
+			exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30
+		}
+
+		if (!this.env.USER_SECRET_KEY || !this.env.REFRESH_SECRET_KEY) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'JWT secrets are not properly configured.'
+			})
+		}
+
+		const accessToken = await sign(payloadAccessToken, this.env.USER_SECRET_KEY)
+		const refreshToken = await sign(
+			payloadRefreshToken,
+			this.env.REFRESH_SECRET_KEY
+		)
+
+		return { accessToken, refreshToken, accessTokenExp: payloadAccessToken.exp }
+	}
+
+	private validation(data: IAuthPasswordDTO): void {
+		if (!data.email && !data.username) {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Either email or username must be provided.'
+			})
+		}
+
+		const isValidData = authSchema.check(data)
+
+		if (!isValidData.success) {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Validation failed',
+				cause: {
+					field: isValidData.field,
+					cause: `is not ${isValidData.failedValidator}`
+				}
+			})
+		}
+	}
+}

--- a/src/types/envVariables.ts
+++ b/src/types/envVariables.ts
@@ -1,0 +1,4 @@
+export type Secrets = {
+	USER_SECRET_KEY?: string
+	REFRESH_SECRET_KEY?: string
+}

--- a/src/validations/users/Auth.Validation.ts
+++ b/src/validations/users/Auth.Validation.ts
@@ -1,0 +1,12 @@
+import { validator } from '@src/lib/validator'
+
+export const authSchema = validator.schema(
+	{
+		username: validator.string().max(256).min(1).nullable(),
+		password: validator.string().max(256).min(8),
+		email: validator.string().email().max(256).nullable()
+	},
+	{
+		strict: true
+	}
+)

--- a/tests/handlers/auth/users/Password.failure.test.ts
+++ b/tests/handlers/auth/users/Password.failure.test.ts
@@ -1,0 +1,100 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('User authentication password E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail if database user password not exists', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: null,
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			username: 'johndoe123',
+			password: '123asdf3'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(422)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Unable to complete authentication.'
+		})
+	})
+
+	test('should fail if database user password not exists', async () => {
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secure',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			username: 'johndoe123',
+			password: '123asdf3'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(401)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Access Denied!'
+		})
+	})
+})

--- a/tests/handlers/auth/users/Success.test.ts
+++ b/tests/handlers/auth/users/Success.test.ts
@@ -1,0 +1,131 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import bcrypt from 'bcryptjs'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('User authentication handler E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should authenticate user successfully with username and password', async () => {
+		const encryptedPassword = await bcrypt.hash('secureP@ssw0rd!', 10)
+
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: encryptedPassword,
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'User authenticated successfully',
+			data: {
+				id: '01JHBDWAXFPAKAFK38E1MAM01W',
+				name: 'John Doe',
+				username: 'johndoe123',
+				email: 'johndoe@example.com',
+				token: {
+					accessToken: expect.stringMatching(jwtRegex),
+					refreshToken: expect.stringMatching(jwtRegex),
+					expiresIn: expect.any(Number)
+				}
+			}
+		})
+	})
+
+	test('should authenticate user successfully with email and password', async () => {
+		const encryptedPassword = await bcrypt.hash('secureP@ssw0rd!', 10)
+
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: encryptedPassword,
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			email: 'johndoe@example.com',
+			password: 'secureP@ssw0rd!'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'User authenticated successfully',
+			data: {
+				id: '01JHBDWAXFPAKAFK38E1MAM01W',
+				name: 'John Doe',
+				username: 'johndoe123',
+				email: 'johndoe@example.com',
+				token: {
+					accessToken: expect.stringMatching(jwtRegex),
+					refreshToken: expect.stringMatching(jwtRegex),
+					expiresIn: expect.any(Number)
+				}
+			}
+		})
+	})
+})

--- a/tests/handlers/auth/users/UserStatus.failure.test.ts
+++ b/tests/handlers/auth/users/UserStatus.failure.test.ts
@@ -1,0 +1,130 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import bcrypt from 'bcryptjs'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('User authentication Status E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when user not exists', async () => {
+		const payload = JSON.stringify({
+			username: 'john Doe',
+			password: '123asdf3'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(404)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'User not founded!'
+		})
+	})
+
+	test('should fail when user has been deleted', async () => {
+		const encryptedPassword = await bcrypt.hash('secureP@ssw0rd!', 10)
+
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: encryptedPassword,
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: date,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			username: 'johndoe123',
+			password: '123456789'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(404)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'User has been deleted!'
+		})
+	})
+
+	test('should fail when user is inactive', async () => {
+		const encryptedPassword = await bcrypt.hash('secureP@ssw0rd!', 10)
+
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: encryptedPassword,
+			email: 'johndoe@example.com',
+			isActive: false,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(404)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'User is inactive!'
+		})
+	})
+})

--- a/tests/handlers/auth/users/Validation.failure.test.ts
+++ b/tests/handlers/auth/users/Validation.failure.test.ts
@@ -1,0 +1,144 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { drizzle } from 'drizzle-orm/d1'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('User authentication Input Validation - E2E', () => {
+	const db = drizzle(env.DB)
+
+	const headers = {
+		'Content-Type': 'application/json',
+		'X-CSRF-Token': 'mock-csrf-token'
+	}
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail when just password is provided', async () => {
+		const payload = JSON.stringify({
+			password: 'secureP@ssw0rd!'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Either email or username must be provided.'
+		})
+	})
+
+	test('should fail when password is not provided', async () => {
+		const payload = JSON.stringify({
+			email: 'johndoe@example.com'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				cause: 'is not nullable',
+				field: 'password'
+			}
+		})
+	})
+
+	test('should fail when email is not email format', async () => {
+		const payload = JSON.stringify({
+			email: 'johndoe',
+			password: 'secureP@ssw0rd!'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				cause: 'is not email',
+				field: 'email'
+			}
+		})
+	})
+
+	test('should fail when body is empty', async () => {
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Invalid JSON format in request body'
+		})
+	})
+
+	test('should fail when email and username is not provided', async () => {
+		const payload = JSON.stringify({})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Either email or username must be provided.'
+		})
+	})
+})

--- a/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
+++ b/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
@@ -27,20 +27,18 @@ describe('Create User failure tests', () => {
 		const usersRepository = new UserRepository(env.DB)
 		const createUserService = new CreateUserService(usersRepository)
 
-		vitest.spyOn(usersRepository, 'findOneByOr').mockResolvedValueOnce([
-			{
-				id: '01JHBDWAXFPAKAFK38E1MAM01W',
-				name: 'John Doe',
-				username: 'johndoe123',
-				password: 'secureP@ssw0rd!',
-				email: 'johndoe@example.com',
-				isActive: true,
-				deletedAt: null,
-				kats: 0,
-				rank: 0,
-				createdAt: new Date().toISOString()
-			}
-		])
+		vitest.spyOn(usersRepository, 'findOneByOr').mockResolvedValueOnce({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: new Date().toISOString()
+		})
 
 		await db.insert(users).values({
 			id: '01JHBDWAXFPAKAFK38E1MAM01W',


### PR DESCRIPTION
## Changes Made

This PR introduces an endpoint for JWT authentication, allowing clients to authenticate using either an email or username along with a password. Upon successful authentication, the endpoint returns a JWT token, which is required for performing sensitive operations, such as updating user information and other protected routes.

The password check is securely handled using the bcrypt hashing algorithm, ensuring the application’s security. This method provides strong protection for sensitive user data.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
