### PR TITLE
Add Totp Library for Two-Factor Authentication (2FA) Support

### DIFF
--- a/src/lib/totp/index.ts
+++ b/src/lib/totp/index.ts
@@ -1,0 +1,132 @@
+import crypto from 'node:crypto'
+
+export class Totp {
+	public generateSecret({ name }: { name: string }): {
+		secret?: string
+		otpauthUrl?: string
+		error?: string
+	} {
+		const urlParamRegex = /^[A-Za-z0-9_-]+$/
+		if (!urlParamRegex.test(name)) {
+			return { error: 'Invalid name.' }
+		}
+
+		const secret = this.generateTOTPSecret()
+		const otpauthUrl = `otpauth://totp/${name}?secret=${secret}`
+
+		return {
+			secret,
+			otpauthUrl
+		}
+	}
+
+	public check(
+		secret: string,
+		token: string,
+		window = 1
+	): { isValid: boolean; error?: string } {
+		const secretRegex = /^[A-Z2-7]+=*$/
+
+		if (!secretRegex.test(secret)) {
+			return { isValid: false, error: 'Invalid Base32 secret.' }
+		}
+
+		const tokenRegex = /^\d{6}$/
+
+		if (!tokenRegex.test(token)) {
+			return { isValid: false, error: 'Invalid token.' }
+		}
+
+		const currentTime = Math.floor(Date.now() / 1000 / 30)
+
+		for (let i = -window; i <= window; i++) {
+			const generatedToken = this.generateToken(secret, currentTime + i)
+
+			if (!generatedToken) {
+				return {
+					isValid: false,
+					error: 'Invalid secret.'
+				}
+			}
+			if (
+				crypto.timingSafeEqual(Buffer.from(token), Buffer.from(generatedToken))
+			) {
+				return {
+					isValid: true
+				}
+			}
+		}
+
+		return { isValid: false }
+	}
+
+	private toBase32(buffer: Buffer<ArrayBufferLike>): string {
+		const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+
+		let bits = ''
+		let base32 = ''
+
+		for (const byte of buffer) {
+			bits += byte.toString(2).padStart(8, '0')
+		}
+
+		for (let i = 0; i < bits.length; i += 5) {
+			const chunk = bits.slice(i, i + 5)
+			base32 += base32Chars[Number.parseInt(chunk.padEnd(5, '0'), 2)]
+		}
+
+		return base32
+	}
+
+	private generateToken(secret: string, counter: number): string | null {
+		const key = this.fromBase32(secret)
+
+		if (!key) {
+			return null
+		}
+
+		const buffer = Buffer.alloc(8)
+		let localCounter = counter
+
+		for (let i = 7; i >= 0; i--) {
+			buffer[i] = localCounter & 0xff
+			localCounter >>= 8
+		}
+
+		const hmac = crypto.createHmac('sha1', key).update(buffer).digest()
+		const offset = hmac[hmac.length - 1] & 0xf
+		const code =
+			((hmac[offset] & 0x7f) << 24) |
+			((hmac[offset + 1] & 0xff) << 16) |
+			((hmac[offset + 2] & 0xff) << 8) |
+			(hmac[offset + 3] & 0xff)
+
+		return (code % 10 ** 6).toString().padStart(6, '0')
+	}
+
+	private fromBase32(base32: string): Buffer | null {
+		const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+		let bits = ''
+
+		for (const char of base32.toUpperCase()) {
+			const index = base32Chars.indexOf(char)
+			if (index === -1) {
+				return null
+			}
+			bits += index.toString(2).padStart(5, '0')
+		}
+
+		const bytes = []
+		for (let i = 0; i < bits.length; i += 8) {
+			bytes.push(Number.parseInt(bits.slice(i, i + 8).padEnd(8, '0'), 2))
+		}
+
+		return Buffer.from(bytes)
+	}
+
+	private generateTOTPSecret(): string {
+		const binarySecret = crypto.randomBytes(20)
+		const base32Secret = this.toBase32(binarySecret)
+		return base32Secret
+	}
+}

--- a/tests/lib/totp/Failure.test.ts
+++ b/tests/lib/totp/Failure.test.ts
@@ -1,0 +1,38 @@
+import { Totp } from '@src/lib/totp'
+import { describe, expect, test } from 'vitest'
+
+describe('Time based one tap password Library Failure', () => {
+	test('should fail with wrong name format', () => {
+		const totp = new Totp()
+
+		const secret = totp.generateSecret({ name: 'Legion API' })
+
+		expect(secret).toStrictEqual({
+			error: 'Invalid name.'
+		})
+	})
+
+	test('should fail with invalid secret base32', () => {
+		const totp = new Totp()
+
+		const secret = totp.check('Invalid Secret', '123545')
+
+		expect(secret).toStrictEqual({
+			isValid: false,
+			error: 'Invalid Base32 secret.'
+		})
+	})
+
+	test('should fail with invalid token', () => {
+		const totp = new Totp()
+
+		const secret = totp.generateSecret({ name: 'LegionAPI' })
+
+		const isValid = totp.check(secret.secret ?? '', 'invalid token')
+
+		expect(isValid).toStrictEqual({
+			isValid: false,
+			error: 'Invalid token.'
+		})
+	})
+})

--- a/tests/lib/totp/Success.test.ts
+++ b/tests/lib/totp/Success.test.ts
@@ -1,0 +1,60 @@
+import crypto from 'node:crypto'
+import { Totp } from '@src/lib/totp'
+import { describe, expect, test } from 'vitest'
+
+describe('Time based one tap password Library', () => {
+	function generateToken(secret: string, counter: number): string {
+		const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+		let bits = ''
+
+		for (const char of secret.toUpperCase()) {
+			const index = base32Chars.indexOf(char)
+			if (index === -1) {
+				throw new Error('Invalid Base32 secret')
+			}
+			bits += index.toString(2).padStart(5, '0')
+		}
+
+		const bytes = []
+		for (let i = 0; i < bits.length; i += 8) {
+			bytes.push(Number.parseInt(bits.slice(i, i + 8).padEnd(8, '0'), 2))
+		}
+
+		const key = Buffer.from(bytes)
+		const buffer = Buffer.alloc(8)
+
+		let localCounter = counter
+		for (let i = 7; i >= 0; i--) {
+			buffer[i] = localCounter & 0xff
+			localCounter >>= 8
+		}
+
+		const hmac = crypto.createHmac('sha1', key).update(buffer).digest()
+		const offset = hmac[hmac.length - 1] & 0xf
+		const code =
+			((hmac[offset] & 0x7f) << 24) |
+			((hmac[offset + 1] & 0xff) << 16) |
+			((hmac[offset + 2] & 0xff) << 8) |
+			(hmac[offset + 3] & 0xff)
+
+		return (code % 10 ** 6).toString().padStart(6, '0')
+	}
+
+	test('should generate secret and otpauth url and authenticate token successfully', () => {
+		const totp = new Totp()
+
+		const secret = totp.generateSecret({ name: 'LegionAPI' })
+
+		expect(secret).toHaveProperty('secret')
+		expect(secret).toHaveProperty('otpauthUrl')
+		expect(secret.error).toBeUndefined()
+
+		const currentTime = Math.floor(Date.now() / 1000 / 30)
+		const token = generateToken(secret.secret ?? '', currentTime)
+
+		const isValid = totp.check(secret.secret ?? '', token)
+		expect(isValid).toStrictEqual({
+			isValid: true
+		})
+	})
+})


### PR DESCRIPTION
## Changes Made

This PR introduces the `Totp` library to enable Two-Factor Authentication (2FA) and passwordless authentication. The library provides methods to generate a `secret` and `otpauthUrl`, making it easy to integrate with 2FA applications and implement robust authentication mechanisms.

Developers can securely generate and validate time-based one-time passwords (TOTP) using this library. Below is an example of how to generate a secret for a user:

```typescript
import { Totp } from '@src/lib/totp'

const secret = totp.generateSecret({ name: 'LegionAPI' })
```

The generated `secret` is a Base32-encoded string with a character set `[A-Z2-7]` and a length of 32 characters. The `name` parameter must be a string containing only letters, numbers, underscores (`_`), or hyphens (`-`).

Example result:

```typescript
{
  secret: 'C7RBJIBP4FUGG7SGY2SYN4JCXYR5XAOR',
  otpauthUrl: 'otpauth://totp/LegionAPI?secret=C7RBJIBP4FUGG7SGY2SYN4JCXYR5XAOR'
}
```

The `check` method verifies if a provided `token` matches the given `secret`, ensuring secure validation of TOTP codes:

```typescript
import { Totp } from '@src/lib/totp'

const isValid = totp.check('C7RBJIBP4FUGG7SGY2SYN4JCXYR5XAOR', '123456')
```

 - First parameter (`secret`): The user’s secret, generated using the `.generateSecret()` method.
 - Second parameter (`token`): A 6-digit numeric string provided by the 2FA app where the `otpauthUrl` was registered and expires in 30 seconds.

This method ensures that only non-expired tokens, generated using the correct secret, will pass validation. When the validation succeeds, the method returns:

```typescript
{
  isValid: true
}
```

If the validation fails, it return a field with descriptive error, ensuring robust handling of invalid inputs.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
- [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
