### PR TITLE
Add suport for select algorithm for token generation on Totp

### DIFF
--- a/tests/lib/totp/Failure.test.ts
+++ b/tests/lib/totp/Failure.test.ts
@@ -5,17 +5,39 @@ describe('Time based one tap password Library Failure', () => {
 	test('should fail with wrong name format', () => {
 		const totp = new Totp()
 
-		const secret = totp.generateSecret({ name: 'Legion API' })
+		const secret = totp.generateSecret({
+			user: 'Legion API',
+			algorithm: 'SHA1',
+			service: 'MyApp'
+		})
 
 		expect(secret).toStrictEqual({
-			error: 'Invalid name.'
+			error: 'Invalid user.'
+		})
+	})
+
+	test('should fail with wrong service format', () => {
+		const totp = new Totp()
+
+		const secret = totp.generateSecret({
+			user: 'LegionAPI',
+			algorithm: 'SHA1',
+			service: 'My App'
+		})
+
+		expect(secret).toStrictEqual({
+			error: 'Invalid service.'
 		})
 	})
 
 	test('should fail with invalid secret base32', () => {
 		const totp = new Totp()
 
-		const secret = totp.check('Invalid Secret', '123545')
+		const secret = totp.check({
+			secret: 'Invalid Secret',
+			algorithm: 'sha1',
+			token: '456789'
+		})
 
 		expect(secret).toStrictEqual({
 			isValid: false,
@@ -26,9 +48,17 @@ describe('Time based one tap password Library Failure', () => {
 	test('should fail with invalid token', () => {
 		const totp = new Totp()
 
-		const secret = totp.generateSecret({ name: 'LegionAPI' })
+		const secret = totp.generateSecret({
+			user: 'Mary',
+			algorithm: 'SHA1',
+			service: 'MyApp'
+		})
 
-		const isValid = totp.check(secret.secret ?? '', 'invalid token')
+		const isValid = totp.check({
+			algorithm: 'sha1',
+			secret: secret.secret ?? '',
+			token: 'Invalid token'
+		})
 
 		expect(isValid).toStrictEqual({
 			isValid: false,

--- a/tests/lib/totp/Success.test.ts
+++ b/tests/lib/totp/Success.test.ts
@@ -43,7 +43,11 @@ describe('Time based one tap password Library', () => {
 	test('should generate secret and otpauth url and authenticate token successfully', () => {
 		const totp = new Totp()
 
-		const secret = totp.generateSecret({ name: 'LegionAPI' })
+		const secret = totp.generateSecret({
+			user: 'Mary',
+			algorithm: 'SHA1',
+			service: 'MyApp'
+		})
 
 		expect(secret).toHaveProperty('secret')
 		expect(secret).toHaveProperty('otpauthUrl')
@@ -52,7 +56,11 @@ describe('Time based one tap password Library', () => {
 		const currentTime = Math.floor(Date.now() / 1000 / 30)
 		const token = generateToken(secret.secret ?? '', currentTime)
 
-		const isValid = totp.check(secret.secret ?? '', token)
+		const isValid = totp.check({
+			secret: secret.secret ?? '',
+			algorithm: 'sha1',
+			token
+		})
 		expect(isValid).toStrictEqual({
 			isValid: true
 		})


### PR DESCRIPTION
## Changes Made

This PR enhances the `Totp` library by introducing support for customizable token generation algorithms, allowing developers to choose between `sha1`, `sha256`, and `sha512`, thereby improving flexibility and compatibility with various 2FA security requirements apps.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
