### PR TITLE
Rehash user password on authentication with password

### DIFF
--- a/src/repositories/users/User.Repository.ts
+++ b/src/repositories/users/User.Repository.ts
@@ -162,6 +162,39 @@ export class UserRepository {
 		return updatedUser
 	}
 
+	public async updatePassword(data: User): Promise<User> {
+		const updatePasswordResult = await this.db
+			.update(users)
+			.set({
+				password: data.password
+			})
+			.where(eq(users.id, data.id))
+
+		if (updatePasswordResult.error) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: updatePasswordResult.error
+			})
+		}
+
+		const queriedUser = await this.db
+			.select()
+			.from(users)
+			.where(eq(users.id, data.id))
+			.limit(1)
+
+		if (queriedUser.length === 0) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'User not found after update. Possible data inconsistency.'
+			})
+		}
+
+		const updatedPassword = new User(queriedUser[0])
+
+		return updatedPassword
+	}
+
 	public async delete(id: string): Promise<User> {
 		await this.db
 			.update(users)

--- a/src/services/auth/userAuth/UserAuth.Service.ts
+++ b/src/services/auth/userAuth/UserAuth.Service.ts
@@ -23,6 +23,7 @@ export class UserAuthService {
 		const user = this.validateUserStatus(queryUser)
 
 		await this.validatePassword(data.password, user.password)
+		await this.reHashingPassword(data.password, user)
 
 		const token = await this.jwtManager.generateToken({
 			id: user.id,
@@ -41,6 +42,14 @@ export class UserAuthService {
 				expiresIn: token.accessTokenExp
 			}
 		}
+	}
+
+	private async reHashingPassword(password: string, user: User): Promise<void> {
+		const encryptedPassword = await bcrypt.hash(password, 10)
+
+		user.password = encryptedPassword
+
+		await this.userRepository.updatePassword(user)
 	}
 
 	private async validatePassword(

--- a/tests/handlers/auth/users/Success.test.ts
+++ b/tests/handlers/auth/users/Success.test.ts
@@ -2,6 +2,7 @@ import { applyD1Migrations, env } from 'cloudflare:test'
 import { users } from '@src/db/user.schema'
 import app from '@src/index'
 import bcrypt from 'bcryptjs'
+import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/d1'
 import { afterEach, beforeAll, describe, expect, test } from 'vitest'
 
@@ -127,5 +128,67 @@ describe('User authentication handler E2E', () => {
 				}
 			}
 		})
+	})
+
+	test('should should rehash password on successfully authentication', async () => {
+		const encryptedPassword = await bcrypt.hash('secureP@ssw0rd!', 2)
+
+		const date = new Date().toISOString()
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: encryptedPassword,
+			email: 'johndoe@example.com',
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const payload = JSON.stringify({
+			email: 'johndoe@example.com',
+			password: 'secureP@ssw0rd!'
+		})
+
+		const res = await app.request(
+			'/users/login',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
+
+		const rehashedUser = await db
+			.select()
+			.from(users)
+			.where(eq(users.id, '01JHBDWAXFPAKAFK38E1MAM01W'))
+			.limit(1)
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'User authenticated successfully',
+			data: {
+				id: '01JHBDWAXFPAKAFK38E1MAM01W',
+				name: 'John Doe',
+				username: 'johndoe123',
+				email: 'johndoe@example.com',
+				token: {
+					accessToken: expect.stringMatching(jwtRegex),
+					refreshToken: expect.stringMatching(jwtRegex),
+					expiresIn: expect.any(Number)
+				}
+			}
+		})
+
+		expect(bcrypt.getRounds(rehashedUser[0].password ?? '')).toBe(10)
 	})
 })


### PR DESCRIPTION
## Changes Made

This PR implements password rehashing during user authentication. When a user successfully authenticates using their `email/username` and `password`, the system will rehash their password using the latest `bcrypt` settings and save the updated hash in the database. This enhancement ensures that passwords are continually secured with the most up-to-date hashing standards and higher salt, providing additional protection against potential brute-force attacks as computational capabilities evolve.

Resolves #45 

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
- [x] New feature 
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
