### PR TITLE
Add isTotpEnable to users for Passwordless Authentication Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Allows the creation of a new user in the Legion ecosystem.
 > |---------------|-----------|----------|-------------------------------------|
 > | name          |  string   |**yes**| 	The name for the new user. |
 > | username      |  string   |**yes**| 	The username for the new user. |
+> | isTotpEnable  |  string   |**yes** | 	If `true` the endpoint will return the otpauth URL used by Auth Apps (e.g., Google Authenticator) to register a new TOTP token.    |
 > | password      |  string   |**no** | 	The password for the user. |
 > | email         |  string   |**no** | 	The email for the user.    |
 

--- a/src/db/user.schema.ts
+++ b/src/db/user.schema.ts
@@ -8,6 +8,7 @@ export const users = sqliteTable('users', {
 	email: text({ length: 256 }),
 	kats: integer().default(0),
 	rank: integer(),
+	isTotpEnable: integer({ mode: 'boolean' }).notNull().default(false),
 	isActive: integer({ mode: 'boolean' }).notNull().default(true),
 	createdAt: text().notNull(),
 	deletedAt: text({ length: 24 }),

--- a/src/dtos/User.DTO.ts
+++ b/src/dtos/User.DTO.ts
@@ -6,6 +6,7 @@ export interface IUsersDTO {
 	email?: string | null
 	kats?: number | null
 	rank?: number | null
+	isTotpEnable: boolean
 	isActive: boolean
 	createdAt: string
 	deletedAt?: string | null

--- a/src/dtos/User.DTO.ts
+++ b/src/dtos/User.DTO.ts
@@ -12,3 +12,8 @@ export interface IUsersDTO {
 	deletedAt?: string | null
 	restoredAt?: string | null
 }
+
+export type ISanitizedUserDTO = Omit<
+	IUsersDTO,
+	'password' | 'kats' | 'rank' | 'isTotpEnable'
+>

--- a/src/entities/User.Entity.ts
+++ b/src/entities/User.Entity.ts
@@ -8,6 +8,7 @@ export class User {
 	public email?: string | null
 	public kats?: number | null
 	public rank?: number | null
+	public isTotpEnable!: boolean
 	public isActive!: boolean
 	public createdAt!: string
 	public deletedAt?: string | null

--- a/src/handlers/users/DeleteUser/DeleteUser.Handler.ts
+++ b/src/handlers/users/DeleteUser/DeleteUser.Handler.ts
@@ -1,4 +1,4 @@
-import type { User } from '@src/entities/User.Entity'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import { UserRepository } from '@src/repositories/users/User.Repository'
 import { DeleteUserService } from '@src/services/users/DeleteUser/DeleteUser.Service'
 import type { Presenter } from '@src/types/presenter'
@@ -9,7 +9,9 @@ import type { StatusCode } from 'hono/utils/http-status'
 
 export const DeleteUserHandler = factory.createHandlers(
 	logger(),
-	async (c): Promise<TypedResponse<Presenter<User>, StatusCode>> => {
+	async (
+		c
+	): Promise<TypedResponse<Presenter<ISanitizedUserDTO>, StatusCode>> => {
 		const usersRepository = new UserRepository(c.env.DB)
 		const deleteUserService = new DeleteUserService(usersRepository)
 

--- a/src/handlers/users/GetUserById/GetUserById.Handler.ts
+++ b/src/handlers/users/GetUserById/GetUserById.Handler.ts
@@ -1,5 +1,5 @@
 import type { IGetUserDTO } from '@src/dtos/GetUser.DTO'
-import type { User } from '@src/entities/User.Entity'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import { UserRepository } from '@src/repositories/users/User.Repository'
 import { GetUserByIdService } from '@src/services/users/GetUserById/GetUserById.Service'
 import type { Presenter } from '@src/types/presenter'
@@ -10,7 +10,9 @@ import type { StatusCode } from 'hono/utils/http-status'
 
 export const GetUserByIdHandler = factory.createHandlers(
 	logger(),
-	async (c): Promise<TypedResponse<Presenter<User>, StatusCode>> => {
+	async (
+		c
+	): Promise<TypedResponse<Presenter<ISanitizedUserDTO>, StatusCode>> => {
 		const usersRepository = new UserRepository(c.env.DB)
 		const getUserByIdService = new GetUserByIdService(usersRepository)
 

--- a/src/handlers/users/ListUsers/ListUsers.Handler.ts
+++ b/src/handlers/users/ListUsers/ListUsers.Handler.ts
@@ -1,5 +1,5 @@
 import type { IListDTO, IListResultDTO } from '@src/dtos/List.DTO'
-import type { User } from '@src/entities/User.Entity'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import { UserRepository } from '@src/repositories/users/User.Repository'
 import { ListUsersService } from '@src/services/users/ListUsers/ListUsers.Service'
 import type { Presenter } from '@src/types/presenter'
@@ -12,7 +12,9 @@ export const ListUsersHandler = factory.createHandlers(
 	logger(),
 	async (
 		c
-	): Promise<TypedResponse<Presenter<IListResultDTO<User>>, StatusCode>> => {
+	): Promise<
+		TypedResponse<Presenter<IListResultDTO<ISanitizedUserDTO>>, StatusCode>
+	> => {
 		const usersRepository = new UserRepository(c.env.DB)
 		const listUsersService = new ListUsersService(usersRepository)
 

--- a/src/handlers/users/UpdateUser/UpdateUser.Handler.ts
+++ b/src/handlers/users/UpdateUser/UpdateUser.Handler.ts
@@ -1,4 +1,4 @@
-import type { User } from '@src/entities/User.Entity'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import { AppError } from '@src/errors/AppErrors.Error'
 import { UserRepository } from '@src/repositories/users/User.Repository'
 import { UpdateUserService } from '@src/services/users/UpdateUser/UpdateUser.Service'
@@ -10,7 +10,9 @@ import type { StatusCode } from 'hono/utils/http-status'
 
 export const UpdateUserHandler = factory.createHandlers(
 	logger(),
-	async (c): Promise<TypedResponse<Presenter<User>, StatusCode>> => {
+	async (
+		c
+	): Promise<TypedResponse<Presenter<ISanitizedUserDTO>, StatusCode>> => {
 		const usersRepository = new UserRepository(c.env.DB)
 		const updateUserService = new UpdateUserService(usersRepository)
 

--- a/src/migrations/0004_migration.sql
+++ b/src/migrations/0004_migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `isTotpEnable` integer DEFAULT false NOT NULL;

--- a/src/migrations/meta/0004_snapshot.json
+++ b/src/migrations/meta/0004_snapshot.json
@@ -1,0 +1,115 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "cb754980-4a5a-4e08-a988-df375b9f15ab",
+	"prevId": "4efaec5b-3ad4-42bb-a41a-8aef3f709709",
+	"tables": {
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"kats": {
+					"name": "kats",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isTotpEnable": {
+					"name": "isTotpEnable",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"isActive": {
+					"name": "isActive",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"restoredAt": {
+					"name": "restoredAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/migrations/meta/_journal.json
+++ b/src/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1737073723111,
 			"tag": "0003_migration",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1738094019580,
+			"tag": "0004_migration",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/services/users/CreateUser/CreateUser.Service.ts
+++ b/src/services/users/CreateUser/CreateUser.Service.ts
@@ -20,6 +20,8 @@ export class CreateUserService {
 			user.password = encryptedPassword
 		}
 
+		user.isTotpEnable = data.isTotpEnable === true
+
 		const createdUser = await this.userRepository.create(user)
 
 		return this.sanitizeUser(createdUser)

--- a/src/services/users/DeleteUser/DeleteUser.Service.ts
+++ b/src/services/users/DeleteUser/DeleteUser.Service.ts
@@ -1,4 +1,5 @@
 import type { IIdDTO } from '@src/dtos/Id.DTO'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import type { User } from '@src/entities/User.Entity'
 import { AppError } from '@src/errors/AppErrors.Error'
 import type { UserRepository } from '@src/repositories/users/User.Repository'
@@ -7,7 +8,7 @@ import { idSchema } from '@src/validations/id/Id.Validation'
 export class DeleteUserService {
 	public constructor(private readonly userRepository: UserRepository) {}
 
-	public async execute(data: IIdDTO): Promise<User> {
+	public async execute(data: IIdDTO): Promise<ISanitizedUserDTO> {
 		this.validation(data)
 
 		await this.isDeleted(data)
@@ -17,11 +18,10 @@ export class DeleteUserService {
 		return this.sanitizeUser(deletedUser)
 	}
 
-	private sanitizeUser(user: User): User {
-		user.password = undefined
-		user.restoredAt = undefined
+	private sanitizeUser(user: User): ISanitizedUserDTO {
+		const { password, restoredAt, isTotpEnable, ...sanitizeUser } = user
 
-		return user
+		return sanitizeUser
 	}
 
 	private async isDeleted(user: IIdDTO): Promise<void> {

--- a/src/services/users/GetUserById/GetUserById.Service.ts
+++ b/src/services/users/GetUserById/GetUserById.Service.ts
@@ -1,4 +1,5 @@
 import type { IGetUserDTO } from '@src/dtos/GetUser.DTO'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import type { User } from '@src/entities/User.Entity'
 import { AppError } from '@src/errors/AppErrors.Error'
 import type { UserRepository } from '@src/repositories/users/User.Repository'
@@ -7,7 +8,7 @@ import { getUserByIdSchema } from '@src/validations/users/GetUserById.Validation
 export class GetUserByIdService {
 	public constructor(private readonly userRepository: UserRepository) {}
 
-	public async execute(data: IGetUserDTO): Promise<User> {
+	public async execute(data: IGetUserDTO): Promise<ISanitizedUserDTO> {
 		this.validation(data)
 
 		const user = await this.userRepository.findOneByOr({ id: data.id })
@@ -35,12 +36,15 @@ export class GetUserByIdService {
 		return this.sanitizeUser(user)
 	}
 
-	private sanitizeUser(user: User): User {
-		user.password = undefined
-		user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
-		user.restoredAt = user.restoredAt === null ? undefined : user.restoredAt
+	private sanitizeUser(user: User): ISanitizedUserDTO {
+		const { password, isTotpEnable, ...sanitizeUser } = user
 
-		return user
+		sanitizeUser.deletedAt =
+			user.deletedAt === null ? undefined : user.deletedAt
+		sanitizeUser.restoredAt =
+			user.restoredAt === null ? undefined : user.restoredAt
+
+		return sanitizeUser
 	}
 
 	private validation(data: IGetUserDTO): void {

--- a/src/services/users/ListUsers/ListUsers.Service.ts
+++ b/src/services/users/ListUsers/ListUsers.Service.ts
@@ -1,4 +1,5 @@
 import type { IListDTO, IListResultDTO } from '@src/dtos/List.DTO'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import type { User } from '@src/entities/User.Entity'
 import { AppError } from '@src/errors/AppErrors.Error'
 import type { UserRepository } from '@src/repositories/users/User.Repository'
@@ -7,7 +8,9 @@ import { listUsersSchema } from '@src/validations/users/ListUsers.Validation'
 export class ListUsersService {
 	public constructor(private readonly userRepository: UserRepository) {}
 
-	public async execute(data: IListDTO): Promise<IListResultDTO<User>> {
+	public async execute(
+		data: IListDTO
+	): Promise<IListResultDTO<ISanitizedUserDTO>> {
 		this.validation(data)
 
 		const users = await this.userRepository.findAll({
@@ -35,12 +38,15 @@ export class ListUsersService {
 		}
 	}
 
-	private sanitizeUser(users: User[]): User[] {
+	private sanitizeUser(users: User[]): ISanitizedUserDTO[] {
 		const sanitizedUsers = users.map((user) => {
-			user.password = undefined
-			user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
-			user.restoredAt = user.restoredAt === null ? undefined : user.restoredAt
-			return user
+			const { password, isTotpEnable, ...sanitizeUser } = user
+
+			sanitizeUser.deletedAt =
+				user.deletedAt === null ? undefined : user.deletedAt
+			sanitizeUser.restoredAt =
+				user.restoredAt === null ? undefined : user.restoredAt
+			return sanitizeUser
 		})
 
 		return sanitizedUsers

--- a/src/services/users/UpdateUser/UpdateUser.Service.ts
+++ b/src/services/users/UpdateUser/UpdateUser.Service.ts
@@ -1,4 +1,4 @@
-import type { IUsersDTO } from '@src/dtos/User.DTO'
+import type { ISanitizedUserDTO, IUsersDTO } from '@src/dtos/User.DTO'
 import type { User } from '@src/entities/User.Entity'
 import { AppError } from '@src/errors/AppErrors.Error'
 import type { UserRepository } from '@src/repositories/users/User.Repository'
@@ -7,7 +7,7 @@ import { updateUserSchema } from '@src/validations/users/UpdateUser.Validation'
 export class UpdateUserService {
 	public constructor(private readonly userRepository: UserRepository) {}
 
-	public async execute(data: IUsersDTO): Promise<User> {
+	public async execute(data: IUsersDTO): Promise<ISanitizedUserDTO> {
 		this.validation(data)
 
 		await this.ensureUserExists(data.id)
@@ -19,14 +19,15 @@ export class UpdateUserService {
 		return this.sanitizeUser(updatedUser)
 	}
 
-	private sanitizeUser(user: User): User {
-		user.password = undefined
-		user.kats = undefined
-		user.rank = undefined
-		user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
-		user.restoredAt = user.restoredAt === null ? undefined : user.restoredAt
+	private sanitizeUser(user: User): ISanitizedUserDTO {
+		const { password, kats, rank, isTotpEnable, ...sanitizeUser } = user
 
-		return user
+		sanitizeUser.deletedAt =
+			user.deletedAt === null ? undefined : user.deletedAt
+		sanitizeUser.restoredAt =
+			user.restoredAt === null ? undefined : user.restoredAt
+
+		return sanitizeUser
 	}
 
 	private async ensureUserExists(userId: string): Promise<User> {

--- a/src/validations/users/CreateUser.Validation.ts
+++ b/src/validations/users/CreateUser.Validation.ts
@@ -5,7 +5,8 @@ export const createUserSchema = validator.schema(
 		name: validator.string().max(256).min(1),
 		username: validator.string().max(256).min(1),
 		password: validator.string().max(256).min(8).nullable(),
-		email: validator.string().email().max(256).nullable()
+		email: validator.string().email().max(256).nullable(),
+		isTotpEnable: validator.boolean()
 	},
 	{
 		strict: true

--- a/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
+++ b/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
@@ -33,6 +33,7 @@ describe('Create User failure tests', () => {
 			username: 'johndoe123',
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
+			isTotpEnable: false,
 			isActive: true,
 			deletedAt: null,
 			kats: 0,
@@ -55,7 +56,8 @@ describe('Create User failure tests', () => {
 
 		const payload = {
 			name: 'John Doe',
-			username: 'johndoe1234'
+			username: 'johndoe1234',
+			isTotpEnable: false
 		} as IUsersDTO
 
 		await expect(createUserService.execute(payload)).rejects.toThrowError(
@@ -70,6 +72,7 @@ describe('Create User failure tests', () => {
 			username: 'johndoe123',
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
+			isTotpEnable: false,
 			isActive: true,
 			deletedAt: null,
 			kats: 0,
@@ -80,7 +83,8 @@ describe('Create User failure tests', () => {
 		const payload = JSON.stringify({
 			name: 'John Doe',
 			username: 'johndoe123',
-			password: 'secureP@ssw0rd!'
+			password: 'secureP@ssw0rd!',
+			isTotpEnable: false
 		})
 
 		const res = await app.request(
@@ -110,6 +114,7 @@ describe('Create User failure tests', () => {
 			id: '01JHBDWAXFPAKAFK38E1MAM01W',
 			name: 'John Doe',
 			username: 'johndoe123',
+			isTotpEnable: false,
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
@@ -122,7 +127,8 @@ describe('Create User failure tests', () => {
 		const payload = JSON.stringify({
 			name: 'John Doe',
 			username: 'johndoe1234',
-			email: 'johndoe@example.com'
+			email: 'johndoe@example.com',
+			isTotpEnable: false
 		})
 
 		const res = await app.request(

--- a/tests/handlers/users/CreateUser/Password.test.ts
+++ b/tests/handlers/users/CreateUser/Password.test.ts
@@ -26,6 +26,7 @@ describe('User password encryption - E2E', () => {
 		const payload = JSON.stringify({
 			name: 'John Doe',
 			username: 'johndoe123',
+			isTotpEnable: false,
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com'
 		})

--- a/tests/handlers/users/CreateUser/Success.test.ts
+++ b/tests/handlers/users/CreateUser/Success.test.ts
@@ -26,7 +26,8 @@ describe('Create User handler E2E', () => {
 			name: 'John Doe',
 			username: 'johndoe123',
 			password: 'secureP@ssw0rd!',
-			email: 'johndoe@example.com'
+			email: 'johndoe@example.com',
+			isTotpEnable: false
 		})
 
 		const res = await app.request(
@@ -56,6 +57,7 @@ describe('Create User handler E2E', () => {
 				name: 'John Doe',
 				username: 'johndoe123',
 				email: 'johndoe@example.com',
+				isTotpEnable: false,
 				isActive: true,
 				createdAt: user.createdAt
 			}
@@ -65,6 +67,7 @@ describe('Create User handler E2E', () => {
 	test('should create user successfully with username', async () => {
 		const payload = JSON.stringify({
 			name: 'John Doe',
+			isTotpEnable: false,
 			username: 'johndoe123'
 		})
 
@@ -94,6 +97,7 @@ describe('Create User handler E2E', () => {
 				id: user.id,
 				name: 'John Doe',
 				username: 'johndoe123',
+				isTotpEnable: false,
 				isActive: true,
 				createdAt: user.createdAt
 			}
@@ -104,6 +108,7 @@ describe('Create User handler E2E', () => {
 		const payload = JSON.stringify({
 			name: 'John Doe',
 			username: 'johndoe123',
+			isTotpEnable: false,
 			email: 'johndoe@example.com'
 		})
 
@@ -134,6 +139,7 @@ describe('Create User handler E2E', () => {
 				name: 'John Doe',
 				username: 'johndoe123',
 				email: 'johndoe@example.com',
+				isTotpEnable: false,
 				isActive: true,
 				createdAt: user.createdAt
 			}
@@ -144,6 +150,7 @@ describe('Create User handler E2E', () => {
 		const payload = JSON.stringify({
 			name: 'John Doe',
 			username: 'johndoe123',
+			isTotpEnable: false,
 			password: 'secureP@ssw0rd!'
 		})
 
@@ -173,6 +180,7 @@ describe('Create User handler E2E', () => {
 				id: user.id,
 				name: 'John Doe',
 				username: 'johndoe123',
+				isTotpEnable: false,
 				isActive: true,
 				createdAt: user.createdAt
 			}

--- a/tests/handlers/users/DeleteUser/Success.test.ts
+++ b/tests/handlers/users/DeleteUser/Success.test.ts
@@ -25,6 +25,7 @@ describe('Delete User handler E2E', () => {
 			username: 'johndoe123',
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
+			isTotpEnable: false,
 			isActive: true,
 			deletedAt: null,
 			kats: 0,

--- a/tests/handlers/users/UpdateUser/Success.test.ts
+++ b/tests/handlers/users/UpdateUser/Success.test.ts
@@ -25,6 +25,7 @@ describe('Update User handler E2E', () => {
 			password: 'secureP@ssw0rd!',
 			email: 'johndoe@example.com',
 			isActive: true,
+			isTotpEnable: false,
 			deletedAt: null,
 			kats: 0,
 			rank: 0,


### PR DESCRIPTION
## Changes Made

This PR adds a new boolean column, `isTotpEnable`, to the `users` database table. This feature allows for passwordless user creation by enabling TOTP (Time-based One-Time Password) authentication. When creating a new user, the payload can be set as follows:

```typescript
{
    "name": "John Doe",
    "username": "johndoee",
    "isTotpEnable": false
}
```

With this new field, you can now easily determine if a user has TOTP enabled by checking the value of isTotpEnable. This eliminates the need to perform joins with the future TOTP tokens table, simplifying the query logic.
Also some tests was updated by adding the new field to it.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
 - [x] _**Breaking change**_ (The creation user endpoint now requires the boolean field `isTotpEnable` in body payload to successful create new user) 
 - [x] Documentation update 

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
