### PR TITLE
 Return otpauth URL in the create user endpoint #52 

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'drizzle-kit'
 
 export default defineConfig({
 	dialect: 'sqlite',
-	schema: ['./src/db/user.schema.ts'],
+	schema: ['./src/db/user.schema.ts', './src/db/otp.schema.ts'],
 	out: './src/migrations'
 })

--- a/src/db/otp.schema.ts
+++ b/src/db/otp.schema.ts
@@ -1,0 +1,17 @@
+import { relations } from 'drizzle-orm'
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { users } from './user.schema'
+
+export const otps = sqliteTable('otps', {
+	id: text().notNull(),
+	otpHash: text({ length: 256 }).notNull(),
+	userId: text('user_id').notNull(),
+	createdAt: text().notNull()
+})
+
+export const otpsRelations = relations(otps, ({ one }) => ({
+	user: one(users, {
+		fields: [otps.userId],
+		references: [users.id]
+	})
+}))

--- a/src/db/user.schema.ts
+++ b/src/db/user.schema.ts
@@ -1,4 +1,6 @@
+import { relations } from 'drizzle-orm'
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { otps } from './otp.schema'
 
 export const users = sqliteTable('users', {
 	id: text().notNull(),
@@ -14,3 +16,7 @@ export const users = sqliteTable('users', {
 	deletedAt: text({ length: 24 }),
 	restoredAt: text({ length: 24 })
 })
+
+export const usersRelations = relations(users, ({ many }) => ({
+	otps: many(otps)
+}))

--- a/src/dtos/Otp.DTO.ts
+++ b/src/dtos/Otp.DTO.ts
@@ -1,0 +1,6 @@
+export interface IOtpDTO {
+	id: string
+	otpHash: string
+	userId: string
+	createdAt: string
+}

--- a/src/dtos/User.DTO.ts
+++ b/src/dtos/User.DTO.ts
@@ -16,4 +16,6 @@ export interface IUsersDTO {
 export type ISanitizedUserDTO = Omit<
 	IUsersDTO,
 	'password' | 'kats' | 'rank' | 'isTotpEnable'
->
+> & {
+	otpauth?: string
+}

--- a/src/entities/Otp.Entity.ts
+++ b/src/entities/Otp.Entity.ts
@@ -1,0 +1,20 @@
+import { ulid } from 'ulid'
+
+export class Otp {
+	public readonly id!: string
+	public otpHash!: string
+	public userId!: string
+	public createdAt!: string
+
+	public constructor(props: Omit<Otp, 'id'>) {
+		Object.assign(this, props)
+
+		if (this.id == null) {
+			this.id = ulid()
+		}
+
+		if (!this.createdAt) {
+			this.createdAt = new Date().toISOString()
+		}
+	}
+}

--- a/src/handlers/users/CreateUser/CreateUser.Handler.ts
+++ b/src/handlers/users/CreateUser/CreateUser.Handler.ts
@@ -1,5 +1,6 @@
-import type { User } from '@src/entities/User.Entity'
+import type { ISanitizedUserDTO } from '@src/dtos/User.DTO'
 import { AppError } from '@src/errors/AppErrors.Error'
+import { OtpRepository } from '@src/repositories/auth/Otp.Repository'
 import { UserRepository } from '@src/repositories/users/User.Repository'
 import { CreateUserService } from '@src/services/users/CreateUser/CreateUser.Service'
 import type { Presenter } from '@src/types/presenter'
@@ -10,9 +11,16 @@ import type { StatusCode } from 'hono/utils/http-status'
 
 export const CreateUserHandler = factory.createHandlers(
 	logger(),
-	async (c): Promise<TypedResponse<Presenter<User>, StatusCode>> => {
+	async (
+		c
+	): Promise<TypedResponse<Presenter<ISanitizedUserDTO>, StatusCode>> => {
 		const usersRepository = new UserRepository(c.env.DB)
-		const createUserService = new CreateUserService(usersRepository)
+		const otpsRepository = new OtpRepository(c.env.DB)
+		const createUserService = new CreateUserService(
+			usersRepository,
+			otpsRepository,
+			c.env.OTP_SECRET
+		)
 
 		const data = await c.req.json().catch(() => {
 			throw new AppError({

--- a/src/lib/totp/index.ts
+++ b/src/lib/totp/index.ts
@@ -14,7 +14,7 @@ export class Totp {
 		otpauthUrl?: string
 		error?: string
 	} {
-		const urlParamRegex = /^[A-Za-z0-9_-]+$/
+		const urlParamRegex = /^[A-Za-z0-9._-]+$/
 		if (!urlParamRegex.test(user)) {
 			return { error: 'Invalid user.' }
 		}

--- a/src/migrations/0005_migration.sql
+++ b/src/migrations/0005_migration.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `otps` (
+	`id` text NOT NULL,
+	`otpHash` text(256) NOT NULL,
+	`user_id` text NOT NULL,
+	`createdAt` text NOT NULL
+);

--- a/src/migrations/meta/0005_snapshot.json
+++ b/src/migrations/meta/0005_snapshot.json
@@ -1,0 +1,153 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "64338024-d57c-4407-b2f6-1bf695f9ac93",
+	"prevId": "cb754980-4a5a-4e08-a988-df375b9f15ab",
+	"tables": {
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"kats": {
+					"name": "kats",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isTotpEnable": {
+					"name": "isTotpEnable",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"isActive": {
+					"name": "isActive",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"restoredAt": {
+					"name": "restoredAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"otps": {
+			"name": "otps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"otpHash": {
+					"name": "otpHash",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/migrations/meta/_journal.json
+++ b/src/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1738094019580,
 			"tag": "0004_migration",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1738200383839,
+			"tag": "0005_migration",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/repositories/auth/Otp.Repository.ts
+++ b/src/repositories/auth/Otp.Repository.ts
@@ -1,0 +1,49 @@
+import { otps } from '@src/db/otp.schema'
+import type {} from '@src/dtos/Pagination.DTO'
+import { Otp } from '@src/entities/Otp.Entity'
+import { AppError } from '@src/errors/AppErrors.Error'
+import { eq } from 'drizzle-orm'
+import { type DrizzleD1Database, drizzle } from 'drizzle-orm/d1'
+
+export class OtpRepository {
+	private db: DrizzleD1Database<Record<string, never>> & {
+		$client: D1Database
+	}
+
+	public constructor(D1: D1Database) {
+		this.db = drizzle(D1)
+	}
+
+	public async create(data: Otp): Promise<Otp> {
+		const process = await this.db.insert(otps).values({
+			id: data.id,
+			otpHash: data.otpHash,
+			userId: data.userId,
+			createdAt: data.createdAt
+		})
+
+		if (process.error) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: process.error
+			})
+		}
+
+		const totp = await this.db
+			.select()
+			.from(otps)
+			.where(eq(otps.id, data.id))
+			.limit(1)
+
+		if (totp.length === 0) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'User not found after update. Possible data inconsistency.'
+			})
+		}
+
+		const createdUser = new Otp(totp[0])
+
+		return createdUser
+	}
+}

--- a/src/services/users/CreateUser/CreateUser.Service.ts
+++ b/src/services/users/CreateUser/CreateUser.Service.ts
@@ -1,14 +1,22 @@
-import type { IUsersDTO } from '@src/dtos/User.DTO'
+import type { ISanitizedUserDTO, IUsersDTO } from '@src/dtos/User.DTO'
+import { Otp } from '@src/entities/Otp.Entity'
 import { User } from '@src/entities/User.Entity'
 import { AppError } from '@src/errors/AppErrors.Error'
+import { Totp } from '@src/lib/totp'
+import { WebCryptoAES } from '@src/lib/webCryptoAES'
+import type { OtpRepository } from '@src/repositories/auth/Otp.Repository'
 import type { UserRepository } from '@src/repositories/users/User.Repository'
 import { createUserSchema } from '@src/validations/users/CreateUser.Validation'
 import bcrypt from 'bcryptjs'
 
 export class CreateUserService {
-	public constructor(private readonly userRepository: UserRepository) {}
+	public constructor(
+		private readonly userRepository: UserRepository,
+		private readonly otpsRepository: OtpRepository,
+		private readonly otpSecret: string
+	) {}
 
-	public async execute(data: IUsersDTO): Promise<User> {
+	public async execute(data: IUsersDTO): Promise<ISanitizedUserDTO> {
 		this.validation(data)
 
 		const user = new User(data)
@@ -20,22 +28,69 @@ export class CreateUserService {
 			user.password = encryptedPassword
 		}
 
-		user.isTotpEnable = data.isTotpEnable === true
+		user.isTotpEnable = false
 
 		const createdUser = await this.userRepository.create(user)
+		const otpauth = await this.generateOtpauth(createdUser, data.isTotpEnable)
 
-		return this.sanitizeUser(createdUser)
+		return this.sanitizeUser(createdUser, otpauth)
 	}
 
-	private sanitizeUser(user: User): User {
-		user.password = undefined
-		user.kats = undefined
-		user.rank = undefined
-		user.email = user.email === null ? undefined : user.email
-		user.deletedAt = user.deletedAt === null ? undefined : user.deletedAt
-		user.restoredAt = user.restoredAt === null ? undefined : user.restoredAt
+	private sanitizeUser(user: User, otpauth?: string): ISanitizedUserDTO {
+		const { password, isTotpEnable, kats, rank, ...sanitizeUser } = user
 
-		return user
+		sanitizeUser.email = user.email === null ? undefined : user.email
+		sanitizeUser.deletedAt =
+			user.deletedAt === null ? undefined : user.deletedAt
+		sanitizeUser.restoredAt =
+			user.restoredAt === null ? undefined : user.restoredAt
+
+		return { ...sanitizeUser, otpauth }
+	}
+
+	private async generateOtpauth(
+		user: User,
+		isTotpEnable: boolean
+	): Promise<string | undefined> {
+		if (!isTotpEnable) {
+			return undefined
+		}
+
+		const totp = new Totp()
+
+		const secret = totp.generateSecret({
+			algorithm: 'SHA256',
+			service: 'LegionKimitri',
+			user: user.username
+		})
+
+		if (secret.error || !secret.secret || !secret.otpauthUrl) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'Error in TOTP secret generation'
+			})
+		}
+
+		const webCryptoAES = new WebCryptoAES({ secret: this.otpSecret })
+
+		const hashedTotp = await webCryptoAES.encryptSymetric(secret.secret)
+
+		if (hashedTotp.error || !hashedTotp.cipherText) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'Failed to generate TOTP'
+			})
+		}
+
+		const otp = new Otp({
+			otpHash: hashedTotp.cipherText,
+			userId: user.id,
+			createdAt: new Date().toISOString()
+		})
+
+		await this.otpsRepository.create(otp)
+
+		return secret.otpauthUrl
 	}
 
 	private async checkForConflict(user: User): Promise<void> {

--- a/tests/handlers/users/CreateUser/Success.test.ts
+++ b/tests/handlers/users/CreateUser/Success.test.ts
@@ -57,7 +57,6 @@ describe('Create User handler E2E', () => {
 				name: 'John Doe',
 				username: 'johndoe123',
 				email: 'johndoe@example.com',
-				isTotpEnable: false,
 				isActive: true,
 				createdAt: user.createdAt
 			}
@@ -97,7 +96,6 @@ describe('Create User handler E2E', () => {
 				id: user.id,
 				name: 'John Doe',
 				username: 'johndoe123',
-				isTotpEnable: false,
 				isActive: true,
 				createdAt: user.createdAt
 			}
@@ -139,7 +137,6 @@ describe('Create User handler E2E', () => {
 				name: 'John Doe',
 				username: 'johndoe123',
 				email: 'johndoe@example.com',
-				isTotpEnable: false,
 				isActive: true,
 				createdAt: user.createdAt
 			}
@@ -180,8 +177,53 @@ describe('Create User handler E2E', () => {
 				id: user.id,
 				name: 'John Doe',
 				username: 'johndoe123',
-				isTotpEnable: false,
 				isActive: true,
+				createdAt: user.createdAt
+			}
+		})
+	})
+
+	test('should create user successfully and return otpauth', async () => {
+		const payload = JSON.stringify({
+			name: 'John Doe',
+			username: 'johndoe123',
+			password: 'secureP@ssw0rd!',
+			email: 'johndoe@example.com',
+			isTotpEnable: true
+		})
+
+		const res = await app.request(
+			'/users',
+			{
+				method: 'POST',
+				headers,
+				body: payload
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		const [user] = await db
+			.select()
+			.from(users)
+			.where(eq(users.email, 'johndoe@example.com'))
+			.limit(1)
+
+		const otpRegex =
+			/^otpauth:\/\/totp\/[^?]+?\?secret=[A-Z2-7]+&issuer=[^&]+&algorithm=[A-Z0-9]+&digits=6&period=30$/
+
+		expect(res.status).toBe(201)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'User created successfully',
+			data: {
+				id: user.id,
+				name: 'John Doe',
+				username: 'johndoe123',
+				email: 'johndoe@example.com',
+				isActive: true,
+				otpauth: expect.stringMatching(otpRegex),
 				createdAt: user.createdAt
 			}
 		})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,8 @@ export default defineWorkersConfig(async () => {
 							TEST_MIGRATIONS: migrations,
 							USER_SECRET_KEY: process.env.USER_SECRET_KEY ?? '',
 							REFRESH_SECRET_KEY: process.env.REFRESH_SECRET_KEY ?? '',
-							AUTH_ISSUER: process.env.AUTH_ISSUER ?? ''
+							AUTH_ISSUER: process.env.AUTH_ISSUER ?? '',
+							OTP_SECRET: process.env.OTP_SECRET ?? ''
 						},
 						compatibilityDate: '2024-11-20',
 						compatibilityFlags: ['nodejs_compat']


### PR DESCRIPTION
## Changes Made

This PR adds a new feature to the create user endpoint, enabling the generation of an OTP secret and returning an otpauth URL when the `isTotpEnable` input is `true`. This allows users to set up passwordless authentication using apps like Google Authenticator and Microsoft Authenticator.

Additionally, it fixes the `Totp` regex for `user` and `service` strings to allow dots and introduces the `OTP_SECRET` environment variable, which will be used as secret input for WebEncryptAES library to encrypt `Totp` generated secrets. A new database table has also been created to store OTP secrets, which are encrypted using WebEncryptAES before being saved, ensuring enhanced security during authentication.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

- [x] Bug fix 
- [x] New feature 
- [x] _**Breaking change**_ (When `isTotpEnable` is `true` in the create user endpoint, the successful response will return the `otpauth` URL) 
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
