### PR TITLE
Implement generate OTP URL for authenticated clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,50 @@ This endpoint authenticates a user by verifying their email or username along wi
 </details>
 
 <details>
+ <summary><code>POST</code> 🔒 <code><b>/users/{userId}/otp/secret</b></code> <code>Generate One-Time Password (OTP) URL</code></summary>
+ 
+#### Generate One-Time Password (OTP) URL
+This endpoint generates a One-Time Password (OTP) authentication URL for a user. The client can use this URL to generate OTPs through an authenticator app (e.g., Google Authenticator, Microsoft Authenticator) linked to the user’s account.
+
+#### Request 
+
+> #### Header Parameters 
+> | name         |  required | description                                                                                          |
+> |--------------|-----------|------------------------------------------------------------------------------------------------------|
+> | Content-Type |  yes      | Required for operations with a request body. The value is application/. Where the 'format' is 'json'.|
+> | X-CSRF-Token |  yes      | A CSRF token to protect against cross-site request forgery attacks. Must be included in the request.|
+> | Authorization |  yes      | A Bearer token in the format `Bearer <JWT>` for authenticating the request and ensuring access.|
+
+#### Response 
+
+> #### Sample Successful Response 
+>
+> Status Code: `200` <br>
+> application/json
+>```json
+>{
+>    "success": true,
+>    "message": "Otp url generated successfully",
+>    "data": {
+>      "otpauthUrl": "otpauth://totp/jhondoe123?secret=LESZPGTBS5Y33CWCGYTP6CHTVETX5RRV&issuer=LegionKimitri&algorithm=SHA256&digits=6&period=30",
+>    }
+>}
+>```
+
+
+> #### Response Schema
+> application/json
+>| Key         | Type     | Description                                      |
+>|-------------|----------|--------------------------------------------------|
+>| success     | boolean  | Indicates whether the request was successful.    |
+>| message     | string   | A message providing additional context.          |
+>| data        | object   | Contains the generated OTP authentication URL.          |
+>| data.otpauthUrl     | string   | The OTP URL that can be used in an authenticator app.          |
+
+
+</details>
+
+<details>
  <summary><code>PUT</code> <code><b>/users/{userId}/otp</b></code> <code>Enable One-Time Password (OTP) Authentication</code></summary>
  
 #### Enable One-Time Password (OTP) Authentication
@@ -366,7 +410,7 @@ Allows the creation of a new user in the Legion ecosystem.
 </details>
 
 <details>
- <summary><code>PUT</code> <code><b>/users/{userId}</b></code> <code>Update User</code></summary>
+ <summary><code>PUT</code> 🔒 <code><b>/users/{userId}</b></code> <code>Update User</code></summary>
  
 #### Update User
 Allows updating user data but prevents updates if the `username` or `email` already exists in another user's account.
@@ -431,7 +475,7 @@ Allows updating user data but prevents updates if the `username` or `email` alre
 </details>
 
 <details>
- <summary><code>DELETE</code> <code><b>/users/{userId}</b></code> <code>Delete User</code></summary>
+ <summary><code>DELETE</code> 🔒 <code><b>/users/{userId}</b></code> <code>Delete User</code></summary>
  
 #### Delete User
 Allows soft deletion for users. When using this endpoint, users are marked as deleted without permanently removing their data from the database. This approach helps maintain data integrity and prevents potential issues with foreign key constraints.

--- a/src/handlers/auth/users/GenerateOtpAuth.Handler.ts
+++ b/src/handlers/auth/users/GenerateOtpAuth.Handler.ts
@@ -1,0 +1,41 @@
+import { OtpRepository } from '@src/repositories/auth/Otp.Repository'
+import { UserRepository } from '@src/repositories/users/User.Repository'
+import { GenerateOtpAuthUrlService } from '@src/services/auth/otp/GenerateOtpAuthUrl.Service'
+import { SetupUserOtpService } from '@src/services/auth/otp/SetupUserOTP.Service'
+import type { Presenter } from '@src/types/presenter'
+import { factory } from '@src/utils/factory'
+import type { TypedResponse } from 'hono'
+import { logger } from 'hono/logger'
+import type { StatusCode } from 'hono/utils/http-status'
+
+export const GenerateOtpAuthUrlHandler = factory.createHandlers(
+	logger(),
+	async (
+		c
+	): Promise<TypedResponse<Presenter<{ otpauthUrl: string }>, StatusCode>> => {
+		const usersRepository = new UserRepository(c.env.DB)
+		const otpRepository = new OtpRepository(c.env.DB)
+		const setupUserOtp = new SetupUserOtpService(
+			otpRepository,
+			c.env.OTP_SECRET
+		)
+		const generateOtpAuthUrlService = new GenerateOtpAuthUrlService(
+			usersRepository,
+			setupUserOtp,
+			otpRepository
+		)
+
+		const id = c.req.param('id')
+
+		const otpUrl = await generateOtpAuthUrlService.execute({ id })
+
+		return c.json(
+			{
+				success: true,
+				message: 'Otp url generated successfully',
+				data: otpUrl
+			},
+			200
+		)
+	}
+)

--- a/src/repositories/auth/Otp.Repository.ts
+++ b/src/repositories/auth/Otp.Repository.ts
@@ -70,4 +70,17 @@ export class OtpRepository {
 
 		return totp[0]
 	}
+
+	public async delete(id: string): Promise<Otp[] | null> {
+		const process = await this.db
+			.delete(otps)
+			.where(eq(otps.userId, id))
+			.returning()
+
+		if (process.length === 0) {
+			return null
+		}
+
+		return process
+	}
 }

--- a/src/routers/auth.router.ts
+++ b/src/routers/auth.router.ts
@@ -1,10 +1,17 @@
 import { EnableOtpHandler } from '@src/handlers/auth/users/EnableOTP.Handler'
+import { GenerateOtpAuthUrlHandler } from '@src/handlers/auth/users/GenerateOtpAuth.Handler'
 import { UserAuthHandler } from '@src/handlers/auth/users/UserAuth.Handler'
+import { authenticateToken } from '@src/middleware/Auth.middleware'
 import { Hono } from 'hono'
 
 const authRouters = new Hono()
 
 authRouters.post('/users/login', ...UserAuthHandler)
 authRouters.put('/users/:id/otp', ...EnableOtpHandler)
+authRouters.post(
+	'/users/:id/otp/secret',
+	authenticateToken,
+	...GenerateOtpAuthUrlHandler
+)
 
 export default authRouters

--- a/src/services/auth/otp/GenerateOtpAuthUrl.Service.ts
+++ b/src/services/auth/otp/GenerateOtpAuthUrl.Service.ts
@@ -1,0 +1,57 @@
+import type { IIdDTO } from '@src/dtos/Id.DTO'
+import { AppError } from '@src/errors/AppErrors.Error'
+import type { OtpRepository } from '@src/repositories/auth/Otp.Repository'
+import type { UserRepository } from '@src/repositories/users/User.Repository'
+import { idSchema } from '@src/validations/id/Id.Validation'
+import type { SetupUserOtpService } from './SetupUserOTP.Service'
+
+export class GenerateOtpAuthUrlService {
+	public constructor(
+		private readonly userRepository: UserRepository,
+		private readonly setupUserOTP: SetupUserOtpService,
+		private readonly otpRepository: OtpRepository
+	) {}
+
+	public async execute(data: IIdDTO): Promise<{ otpauthUrl: string }> {
+		this.validationInput(data)
+
+		const user = await this.userRepository.findOneByOr({ id: data.id })
+
+		if (!user) {
+			throw new AppError({
+				name: 'Not Found',
+				message: 'User not founded!'
+			})
+		}
+
+		await this.otpRepository.delete(user.id)
+
+		const otp = await this.setupUserOTP.excecute(user, true)
+
+		if (!otp.otpAuthUrl) {
+			throw new AppError({
+				name: 'Conflict',
+				message: 'OTP already enable!'
+			})
+		}
+
+		return {
+			otpauthUrl: otp.otpAuthUrl
+		}
+	}
+
+	private validationInput(data: IIdDTO): void {
+		const isValidData = idSchema.check(data)
+
+		if (!isValidData.success) {
+			throw new AppError({
+				name: 'Bad Request',
+				message: 'Validation failed',
+				cause: {
+					field: isValidData.field,
+					cause: `is not ${isValidData.failedValidator}`
+				}
+			})
+		}
+	}
+}

--- a/tests/handlers/auth/GenerateOTPUrl/GenerateOTPUrl.failure.test.ts
+++ b/tests/handlers/auth/GenerateOTPUrl/GenerateOTPUrl.failure.test.ts
@@ -1,0 +1,112 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { otps } from '@src/db/otp.schema'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { Totp } from '@src/lib/totp'
+import { WebCryptoAES } from '@src/lib/webCryptoAES'
+import { OtpRepository } from '@src/repositories/auth/Otp.Repository'
+import { UserRepository } from '@src/repositories/users/User.Repository'
+import { GenerateOtpAuthUrlService } from '@src/services/auth/otp/GenerateOtpAuthUrl.Service'
+import { SetupUserOtpService } from '@src/services/auth/otp/SetupUserOTP.Service'
+import { drizzle } from 'drizzle-orm/d1'
+import { sign } from 'hono/jwt'
+import { afterEach, beforeAll, describe, expect, test, vitest } from 'vitest'
+
+describe('Get user otp url handler failure cases E2E', () => {
+	const db = drizzle(env.DB)
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should generate user OTP url successfully', async () => {
+		const payloadAccessToken = {
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			iss: env.AUTH_ISSUER,
+			iat: Math.floor(Date.now() / 1000),
+			exp: Math.floor(Date.now() / 1000) + 60 * 60
+		}
+		const accessToken = await sign(payloadAccessToken, env.USER_SECRET_KEY)
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W/otp/secret',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-CSRF-Token': 'mock-csrf-token',
+					authorization: `Bearer ${accessToken}`
+				}
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(404)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'User not founded!'
+		})
+	})
+
+	test('should failed when setupUserOTP return undefined otauthurl', async () => {
+		const totp = new Totp()
+		const webCryptoAES = new WebCryptoAES({ secret: env.OTP_SECRET })
+
+		const date = new Date().toISOString()
+		const userRepository = new UserRepository(env.DB)
+		const otpRepository = new OtpRepository(env.DB)
+		const setupUserOTP = new SetupUserOtpService(otpRepository, env.OTP_SECRET)
+		const generateOtpAuthUrl = new GenerateOtpAuthUrlService(
+			userRepository,
+			setupUserOTP,
+			otpRepository
+		)
+
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			email: 'johndoe@example.com',
+			isTotpEnable: false,
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const secret = totp.generateSecret({
+			algorithm: 'SHA256',
+			service: 'LegionKimitri',
+			user: 'johndoe123'
+		})
+
+		const encryptedSecret = await webCryptoAES.encryptSymetric(
+			secret.secret ?? ''
+		)
+
+		await db.insert(otps).values({
+			id: '01JK4JKV50GPZ8R32DP399WGRQ',
+			otpHash: encryptedSecret.cipherText ?? '',
+			userId: '01JHBDWAXFPAKAFK38E1MAM01W',
+			createdAt: date
+		})
+
+		vitest.spyOn(setupUserOTP, 'excecute').mockResolvedValueOnce({
+			otpAuthUrl: undefined,
+			secret: undefined
+		})
+
+		await expect(
+			generateOtpAuthUrl.execute({ id: '01JHBDWAXFPAKAFK38E1MAM01W' })
+		).rejects.toThrowError('OTP already enable!')
+	})
+})

--- a/tests/handlers/auth/GenerateOTPUrl/Success.test.ts
+++ b/tests/handlers/auth/GenerateOTPUrl/Success.test.ts
@@ -1,0 +1,95 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { otps } from '@src/db/otp.schema'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { Totp } from '@src/lib/totp'
+import { WebCryptoAES } from '@src/lib/webCryptoAES'
+import { drizzle } from 'drizzle-orm/d1'
+import { sign } from 'hono/jwt'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Get user otp url handler E2E', () => {
+	const db = drizzle(env.DB)
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should generate user OTP url successfully', async () => {
+		const totp = new Totp()
+		const webCryptoAES = new WebCryptoAES({ secret: env.OTP_SECRET })
+
+		const date = new Date().toISOString()
+
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			email: 'johndoe@example.com',
+			isTotpEnable: false,
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const secret = totp.generateSecret({
+			algorithm: 'SHA256',
+			service: 'LegionKimitri',
+			user: 'johndoe123'
+		})
+
+		const encryptedSecret = await webCryptoAES.encryptSymetric(
+			secret.secret ?? ''
+		)
+
+		await db.insert(otps).values({
+			id: '01JK4JKV50GPZ8R32DP399WGRQ',
+			otpHash: encryptedSecret.cipherText ?? '',
+			userId: '01JHBDWAXFPAKAFK38E1MAM01W',
+			createdAt: date
+		})
+
+		const payloadAccessToken = {
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			iss: env.AUTH_ISSUER,
+			iat: Math.floor(Date.now() / 1000),
+			exp: Math.floor(Date.now() / 1000) + 60 * 60
+		}
+		const accessToken = await sign(payloadAccessToken, env.USER_SECRET_KEY)
+
+		const res = await app.request(
+			'/users/01JHBDWAXFPAKAFK38E1MAM01W/otp/secret',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-CSRF-Token': 'mock-csrf-token',
+					authorization: `Bearer ${accessToken}`
+				}
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		const otpAuthRegex =
+			/^otpauth:\/\/totp\/([\w-]+)\?secret=([A-Z2-7]{16,32})&issuer=([\w\s-]+)&algorithm=(SHA1|SHA256|SHA512)&digits=(6|8)&period=(\d+)$/
+
+		expect(res.status).toBe(200)
+		expect(result).toStrictEqual({
+			success: true,
+			message: 'Otp url generated successfully',
+			data: {
+				otpauthUrl: expect.stringMatching(otpAuthRegex)
+			}
+		})
+	})
+})

--- a/tests/handlers/auth/GenerateOTPUrl/Validation.failure.test.ts
+++ b/tests/handlers/auth/GenerateOTPUrl/Validation.failure.test.ts
@@ -1,0 +1,93 @@
+import { applyD1Migrations, env } from 'cloudflare:test'
+import { otps } from '@src/db/otp.schema'
+import { users } from '@src/db/user.schema'
+import app from '@src/index'
+import { Totp } from '@src/lib/totp'
+import { WebCryptoAES } from '@src/lib/webCryptoAES'
+import { drizzle } from 'drizzle-orm/d1'
+import { sign } from 'hono/jwt'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+describe('Get user otp url validation handler E2E', () => {
+	const db = drizzle(env.DB)
+
+	beforeAll(async () => {
+		await applyD1Migrations(env.DB, env.TEST_MIGRATIONS)
+	})
+
+	afterEach(async () => {
+		await db.delete(users)
+	})
+
+	test('should fail with invalid user id', async () => {
+		const totp = new Totp()
+		const webCryptoAES = new WebCryptoAES({ secret: env.OTP_SECRET })
+
+		const date = new Date().toISOString()
+
+		await db.insert(users).values({
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			email: 'johndoe@example.com',
+			isTotpEnable: false,
+			isActive: true,
+			deletedAt: null,
+			kats: 0,
+			rank: 0,
+			createdAt: date
+		})
+
+		const secret = totp.generateSecret({
+			algorithm: 'SHA256',
+			service: 'LegionKimitri',
+			user: 'johndoe123'
+		})
+
+		const encryptedSecret = await webCryptoAES.encryptSymetric(
+			secret.secret ?? ''
+		)
+
+		await db.insert(otps).values({
+			id: '01JK4JKV50GPZ8R32DP399WGRQ',
+			otpHash: encryptedSecret.cipherText ?? '',
+			userId: '01JHBDWAXFPAKAFK38E1MAM01W',
+			createdAt: date
+		})
+
+		const payloadAccessToken = {
+			id: '01JHBDWAXFPAKAFK38E1MAM01W',
+			name: 'John Doe',
+			username: 'johndoe123',
+			iss: env.AUTH_ISSUER,
+			iat: Math.floor(Date.now() / 1000),
+			exp: Math.floor(Date.now() / 1000) + 60 * 60
+		}
+		const accessToken = await sign(payloadAccessToken, env.USER_SECRET_KEY)
+
+		const res = await app.request(
+			'/users/invalid-id/otp/secret',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-CSRF-Token': 'mock-csrf-token',
+					authorization: `Bearer ${accessToken}`
+				}
+			},
+			env
+		)
+
+		const result = await res.json()
+
+		expect(res.status).toBe(400)
+		expect(result).toStrictEqual({
+			success: false,
+			message: 'Validation failed',
+			cause: {
+				cause: 'is not ulid',
+				field: 'id'
+			}
+		})
+	})
+})

--- a/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
+++ b/tests/handlers/users/CreateUser/AlreadyExists.failure.test.ts
@@ -2,7 +2,9 @@ import { applyD1Migrations, env } from 'cloudflare:test'
 import { users } from '@src/db/user.schema'
 import type { IUsersDTO } from '@src/dtos/User.DTO'
 import app from '@src/index'
+import { OtpRepository } from '@src/repositories/auth/Otp.Repository'
 import { UserRepository } from '@src/repositories/users/User.Repository'
+import { SetupUserOtpService } from '@src/services/auth/otp/SetupUserOTP.Service'
 import { CreateUserService } from '@src/services/users/CreateUser/CreateUser.Service'
 import { drizzle } from 'drizzle-orm/d1'
 import { afterEach, beforeAll, describe, expect, test, vitest } from 'vitest'
@@ -25,7 +27,12 @@ describe('Create User failure tests', () => {
 
 	test('should fail when user with id already exists - unity', async () => {
 		const usersRepository = new UserRepository(env.DB)
-		const createUserService = new CreateUserService(usersRepository)
+		const otpsRepository = new OtpRepository(env.DB)
+		const setupUserOTP = new SetupUserOtpService(otpsRepository, env.OTP_SECRET)
+		const createUserService = new CreateUserService(
+			usersRepository,
+			setupUserOTP
+		)
 
 		vitest.spyOn(usersRepository, 'findOneByOr').mockResolvedValueOnce({
 			id: '01JHBDWAXFPAKAFK38E1MAM01W',


### PR DESCRIPTION
## Changes Made

This PR introduces a new endpoint that enables authenticated users to generate a new One-Time Password (OTP) URL. This URL can be used with authenticator apps such as Google Authenticator, Microsoft Authenticator, etc, to create OTPs for secure authentication.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->


- [x] New feature
- [x] Documentation update 

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [x] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
