### PR TITLE
Breaking Change: Return refreshToken as httpOnly cookie instead of response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,18 @@ This endpoint authenticates a user by verifying their email or username along wi
 >      "email": "john.doe@example.com",
 >      "token": {
 >        "accessToken": "eyJhbGciOiJIUzI1NiIsInR...",
->        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
 >        "expiresIn": "1737648644"
 >        },
 >    }
 >}
 >```
 
+> #### Response Header Parameters 
+> | name         |  name | description                                                                                          |
+> |--------------|-----------|------------------------------------------------------------------------------------------------------|
+> | Set-Cookie   |  refreshToken      | Contains the `refreshToken` that is returned to the client in a HttpOnly cookie. This cookie is used for refreshing the user's `accessToken`|
 
-> #### Response Schema
+> #### Response Body
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -89,12 +92,9 @@ This endpoint authenticates a user by verifying their email or username along wi
 >| data.username    | string   | Username for the authenticated user.                           |
 >| data.token    | object   |   Contains authentication tokens and their expiry.|
 >| data.token.accessToken    | string   | 	The JWT access token.                            |
->| data.token.refreshToken    | string   | 	The JWT access refreshToken.                            |
 >| data.token.expiresIn    | string   | 	The token expiration time (UNIX timestamp).                           |
 
-
 </details>
-
 
 <details>
  <summary><code>POST</code> <code><b>/users/otp/login</b></code> <code>Authenticate User with OTP (One-Time Password)</code></summary>
@@ -134,15 +134,18 @@ This endpoint authenticates a user by verifying their email or username along wi
 >      "email": "john.doe@example.com",
 >      "token": {
 >        "accessToken": "eyJhbGciOiJIUzI1NiIsInR...",
->        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
 >        "expiresIn": "1737648644"
 >        },
 >    }
 >}
 >```
 
+> #### Response Header Parameters 
+> | name         |  name | description                                                                                          |
+> |--------------|-----------|------------------------------------------------------------------------------------------------------|
+> | Set-Cookie   |  refreshToken      | Contains the `refreshToken` that is returned to the client in a HttpOnly cookie. This cookie is used for refreshing the user's `accessToken`|
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -193,7 +196,7 @@ This endpoint generates a One-Time Password (OTP) authentication URL for a user.
 >```
 
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -238,7 +241,7 @@ This endpoint enables One-Time Password (OTP) authentication for a user. The use
 >```
 
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -315,7 +318,7 @@ Retrieves a paginated list of users, with 20 users per page, including detailed 
 >```
 
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -393,7 +396,7 @@ Fetches detailed information about a specific user using the provided `id`. If t
 >```
 
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -458,7 +461,7 @@ Allows the creation of a new user in the Legion ecosystem.
 >```
 
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -524,7 +527,7 @@ Allows updating user data but prevents updates if the `username` or `email` alre
 >```
 
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|
@@ -585,7 +588,7 @@ Allows soft deletion for users. When using this endpoint, users are marked as de
 >```
 
 
-> #### Response Schema
+> #### Response Body Schema
 > application/json
 >| Key         | Type     | Description                                      |
 >|-------------|----------|--------------------------------------------------|

--- a/src/dtos/Auth.DTO.ts
+++ b/src/dtos/Auth.DTO.ts
@@ -21,3 +21,7 @@ export interface IAuthReturnDTO {
 		expiresIn: number
 	}
 }
+
+export type ISanitizedAuthDTO = Omit<IAuthReturnDTO, 'token'> & {
+	token: Omit<IAuthReturnDTO['token'], 'refreshToken'>
+}

--- a/src/handlers/auth/users/OTPAuth.Handler.ts
+++ b/src/handlers/auth/users/OTPAuth.Handler.ts
@@ -1,4 +1,4 @@
-import type { IAuthReturnDTO } from '@src/dtos/Auth.DTO'
+import type { ISanitizedAuthDTO } from '@src/dtos/Auth.DTO'
 import { AppError } from '@src/errors/AppErrors.Error'
 import { OtpRepository } from '@src/repositories/auth/Otp.Repository'
 import { JWTManager } from '@src/services/auth/jwtManager/JWTManager.Service'
@@ -6,12 +6,15 @@ import { OTPAuthService } from '@src/services/auth/otp/OTPAuth.Service'
 import type { Presenter } from '@src/types/presenter'
 import { factory } from '@src/utils/factory'
 import type { TypedResponse } from 'hono'
+import { setCookie } from 'hono/cookie'
 import { logger } from 'hono/logger'
 import type { StatusCode } from 'hono/utils/http-status'
 
 export const OtpAuthHandler = factory.createHandlers(
 	logger(),
-	async (c): Promise<TypedResponse<Presenter<IAuthReturnDTO>, StatusCode>> => {
+	async (
+		c
+	): Promise<TypedResponse<Presenter<ISanitizedAuthDTO>, StatusCode>> => {
 		const jwtManager = new JWTManager({
 			USER_SECRET_KEY: c.env.USER_SECRET_KEY,
 			REFRESH_SECRET_KEY: c.env.REFRESH_SECRET_KEY,
@@ -33,11 +36,28 @@ export const OtpAuthHandler = factory.createHandlers(
 
 		const user = await userAuthService.execute(data)
 
+		setCookie(c, 'refreshToken', user.token.refreshToken, {
+			secure: true,
+			httpOnly: true,
+			sameSite: 'Strict',
+			maxAge: 60 * 60 * 24 * 27,
+			path: '/users/auth/refresh'
+		})
+
 		return c.json(
 			{
 				success: true,
 				message: 'User authenticated successfully',
-				data: user
+				data: {
+					id: user.id,
+					name: user.name,
+					username: user.username,
+					email: user.email ? user.email : undefined,
+					token: {
+						accessToken: user.token.accessToken,
+						expiresIn: user.token.expiresIn
+					}
+				}
 			},
 			200
 		)

--- a/tests/handlers/auth/otpAuth/Success.test.ts
+++ b/tests/handlers/auth/otpAuth/Success.test.ts
@@ -117,9 +117,19 @@ describe('User OTP authentication handler E2E', () => {
 
 		const result = await res.json()
 
+		const cookies = res.headers.getSetCookie()[0]
+
 		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
+		const refreshTokenRegex = cookies.match(/refreshToken=([^;]+)/)?.[1]
 
 		expect(res.status).toBe(200)
+		expect(cookies).toMatch(/refreshToken=/)
+		expect(cookies).toMatch(/HttpOnly/)
+		expect(cookies).toMatch(/Path=\/users\/auth\/refresh/)
+		expect(cookies).toMatch(/Secure/)
+		expect(cookies).toMatch(/SameSite=Strict/)
+		expect(cookies).toMatch(/Max-Age=2332800/)
+		expect(refreshTokenRegex).toMatch(jwtRegex)
 		expect(result).toStrictEqual({
 			success: true,
 			message: 'User authenticated successfully',
@@ -130,7 +140,6 @@ describe('User OTP authentication handler E2E', () => {
 				email: 'johndoe@example.com',
 				token: {
 					accessToken: expect.stringMatching(jwtRegex),
-					refreshToken: expect.stringMatching(jwtRegex),
 					expiresIn: expect.any(Number)
 				}
 			}
@@ -193,9 +202,19 @@ describe('User OTP authentication handler E2E', () => {
 
 		const result = await res.json()
 
+		const cookies = res.headers.getSetCookie()[0]
+
 		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
+		const refreshTokenRegex = cookies.match(/refreshToken=([^;]+)/)?.[1]
 
 		expect(res.status).toBe(200)
+		expect(cookies).toMatch(/refreshToken=/)
+		expect(cookies).toMatch(/HttpOnly/)
+		expect(cookies).toMatch(/Path=\/users\/auth\/refresh/)
+		expect(cookies).toMatch(/Secure/)
+		expect(cookies).toMatch(/SameSite=Strict/)
+		expect(cookies).toMatch(/Max-Age=2332800/)
+		expect(refreshTokenRegex).toMatch(jwtRegex)
 		expect(result).toStrictEqual({
 			success: true,
 			message: 'User authenticated successfully',
@@ -206,7 +225,6 @@ describe('User OTP authentication handler E2E', () => {
 				email: 'johndoe@example.com',
 				token: {
 					accessToken: expect.stringMatching(jwtRegex),
-					refreshToken: expect.stringMatching(jwtRegex),
 					expiresIn: expect.any(Number)
 				}
 			}

--- a/tests/handlers/auth/users/Success.test.ts
+++ b/tests/handlers/auth/users/Success.test.ts
@@ -56,9 +56,19 @@ describe('User authentication handler E2E', () => {
 
 		const result = await res.json()
 
+		const cookies = res.headers.getSetCookie()[0]
+
+		const refreshTokenRegex = cookies.match(/refreshToken=([^;]+)/)?.[1]
 		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
 
 		expect(res.status).toBe(200)
+		expect(cookies).toMatch(/refreshToken=/)
+		expect(cookies).toMatch(/HttpOnly/)
+		expect(cookies).toMatch(/Path=\/users\/auth\/refresh/)
+		expect(cookies).toMatch(/Secure/)
+		expect(cookies).toMatch(/SameSite=Strict/)
+		expect(cookies).toMatch(/Max-Age=2332800/)
+		expect(refreshTokenRegex).toMatch(jwtRegex)
 		expect(result).toStrictEqual({
 			success: true,
 			message: 'User authenticated successfully',
@@ -69,7 +79,6 @@ describe('User authentication handler E2E', () => {
 				email: 'johndoe@example.com',
 				token: {
 					accessToken: expect.stringMatching(jwtRegex),
-					refreshToken: expect.stringMatching(jwtRegex),
 					expiresIn: expect.any(Number)
 				}
 			}
@@ -110,9 +119,19 @@ describe('User authentication handler E2E', () => {
 
 		const result = await res.json()
 
+		const cookies = res.headers.getSetCookie()[0]
+
+		const refreshTokenRegex = cookies.match(/refreshToken=([^;]+)/)?.[1]
 		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
 
 		expect(res.status).toBe(200)
+		expect(cookies).toMatch(/refreshToken=/)
+		expect(cookies).toMatch(/HttpOnly/)
+		expect(cookies).toMatch(/Secure/)
+		expect(cookies).toMatch(/Path=\/users\/auth\/refresh/)
+		expect(cookies).toMatch(/SameSite=Strict/)
+		expect(cookies).toMatch(/Max-Age=2332800/)
+		expect(refreshTokenRegex).toMatch(jwtRegex)
 		expect(result).toStrictEqual({
 			success: true,
 			message: 'User authenticated successfully',
@@ -123,7 +142,6 @@ describe('User authentication handler E2E', () => {
 				email: 'johndoe@example.com',
 				token: {
 					accessToken: expect.stringMatching(jwtRegex),
-					refreshToken: expect.stringMatching(jwtRegex),
 					expiresIn: expect.any(Number)
 				}
 			}
@@ -163,7 +181,9 @@ describe('User authentication handler E2E', () => {
 		)
 
 		const result = await res.json()
+		const cookies = res.headers.getSetCookie()[0]
 
+		const refreshTokenRegex = cookies.match(/refreshToken=([^;]+)/)?.[1]
 		const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
 
 		const rehashedUser = await db
@@ -173,6 +193,13 @@ describe('User authentication handler E2E', () => {
 			.limit(1)
 
 		expect(res.status).toBe(200)
+		expect(cookies).toMatch(/refreshToken=/)
+		expect(cookies).toMatch(/HttpOnly/)
+		expect(cookies).toMatch(/Secure/)
+		expect(cookies).toMatch(/SameSite=Strict/)
+		expect(cookies).toMatch(/Path=\/users\/auth\/refresh/)
+		expect(cookies).toMatch(/Max-Age=2332800/)
+		expect(refreshTokenRegex).toMatch(jwtRegex)
 		expect(result).toStrictEqual({
 			success: true,
 			message: 'User authenticated successfully',
@@ -183,7 +210,6 @@ describe('User authentication handler E2E', () => {
 				email: 'johndoe@example.com',
 				token: {
 					accessToken: expect.stringMatching(jwtRegex),
-					refreshToken: expect.stringMatching(jwtRegex),
 					expiresIn: expect.any(Number)
 				}
 			}


### PR DESCRIPTION
## Changes Made

This PR modifies how the `refreshToken` is returned to the client. Instead of being included in the response body, the refreshToken is now sent as an **httpOnly** cookie via the `Set-Cookie` header.
This enhances security by preventing JavaScript from accessing the token, reducing the risk of XSS attacks.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
<!-- - [x] New feature -->
 - [x] _**Breaking change**_ (The `refreshToken` is no longer included in the login response body; it is now returned in the Set-Cookie header as an httpOnly cookie.) 
 - [x] Documentation update 

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [ ] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
