### PR TITLE
Increase token column length in refreshToken table to support encrypted tokens

### DIFF
--- a/src/db/refreshToken.schema.ts
+++ b/src/db/refreshToken.schema.ts
@@ -5,7 +5,7 @@ import { users } from './user.schema'
 export const refreshToken = sqliteTable('refreshToken', {
 	id: text().notNull(),
 	userId: text('user_id').notNull(),
-	token: text({ length: 256 }).notNull(),
+	token: text({ length: 600 }).notNull(),
 	userAgent: text({ length: 256 }).notNull(),
 	expiresAt: text({ length: 24 }).notNull(),
 	revoked: integer({ mode: 'boolean' }).notNull().default(false),

--- a/src/migrations/0007_migration.sql
+++ b/src/migrations/0007_migration.sql
@@ -1,0 +1,15 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_refreshToken` (
+	`id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`token` text(600) NOT NULL,
+	`userAgent` text(256) NOT NULL,
+	`expiresAt` text(24) NOT NULL,
+	`revoked` integer DEFAULT false NOT NULL,
+	`createdAt` text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_refreshToken`("id", "user_id", "token", "userAgent", "expiresAt", "revoked", "createdAt") SELECT "id", "user_id", "token", "userAgent", "expiresAt", "revoked", "createdAt" FROM `refreshToken`;--> statement-breakpoint
+DROP TABLE `refreshToken`;--> statement-breakpoint
+ALTER TABLE `__new_refreshToken` RENAME TO `refreshToken`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/src/migrations/meta/0007_snapshot.json
+++ b/src/migrations/meta/0007_snapshot.json
@@ -1,0 +1,213 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "f264f3ee-55db-4e0b-b28a-7e6b6f3400f4",
+	"prevId": "46af9253-2c60-4079-b64a-d9591cceb5dd",
+	"tables": {
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"kats": {
+					"name": "kats",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isTotpEnable": {
+					"name": "isTotpEnable",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"isActive": {
+					"name": "isActive",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"deletedAt": {
+					"name": "deletedAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"restoredAt": {
+					"name": "restoredAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"otps": {
+			"name": "otps",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"otpHash": {
+					"name": "otpHash",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"refreshToken": {
+			"name": "refreshToken",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text(600)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text(256)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "text(24)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"revoked": {
+					"name": "revoked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/migrations/meta/_journal.json
+++ b/src/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
 			"when": 1739083551181,
 			"tag": "0006_migration",
 			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "6",
+			"when": 1739463600987,
+			"tag": "0007_migration",
+			"breakpoints": true
 		}
 	]
 }


### PR DESCRIPTION
## Changes Made

This PR increases the length of the `token` column in the `refreshToken` database table from 256 to 600. This change is necessary to accommodate encrypted tokens, which can exceed the previous length limit.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

 - [x] Bug fix 
<!-- - [x] New feature -->
<!-- - [x] _**Breaking change**_ (the change causes a compatibility break in the API) -->
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [ ] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
