### PR TITLE
Encrypt and store refresh token after authentication

### DIFF
--- a/src/dtos/Auth.DTO.ts
+++ b/src/dtos/Auth.DTO.ts
@@ -2,12 +2,14 @@ export type IAuthPasswordDTO = {
 	email?: string
 	password: string
 	username?: string
+	userAgent: string
 } & ({ email: string } | { username: string })
 
 export type IAuthOtpDTO = {
 	email?: string
 	token: string
 	username?: string
+	userAgent: string
 } & ({ email: string } | { username: string })
 
 export interface IAuthReturnDTO {
@@ -24,4 +26,11 @@ export interface IAuthReturnDTO {
 
 export type ISanitizedAuthDTO = Omit<IAuthReturnDTO, 'token'> & {
 	token: Omit<IAuthReturnDTO['token'], 'refreshToken'>
+}
+
+export interface StoreRefreshTokenInput {
+	refreshToken: string
+	userAgent: string
+	userId: string
+	expiresAt: number
 }

--- a/src/dtos/RefreshToken.DTO.ts
+++ b/src/dtos/RefreshToken.DTO.ts
@@ -1,0 +1,15 @@
+export interface IRefreshTokenDTO {
+	id: string
+	userId: string
+	token: string
+	userAgent: string
+	expiresAt: string
+	revoked: boolean
+	createdAt: string
+}
+
+export interface IRefreshTokenParamsDTO {
+	refreshToken: string
+	accessToken: string
+	userAgent: string
+}

--- a/src/dtos/Repositories.DTO.ts
+++ b/src/dtos/Repositories.DTO.ts
@@ -4,6 +4,8 @@ export type IFindByParamsDTO = {
 	id?: string
 	email?: string | null
 	username?: string | null
+	revoked?: boolean
+	noExpired?: boolean
 	andNot?: Partial<Record<keyof IUsersDTO, string>>
 } & (
 	| { id: string }

--- a/src/entities/RefreshToken.Entity.ts
+++ b/src/entities/RefreshToken.Entity.ts
@@ -1,0 +1,23 @@
+import { ulid } from 'ulid'
+
+export class RefreshToken {
+	public readonly id!: string
+	public userId!: string
+	public token!: string
+	public userAgent!: string
+	public expiresAt!: string
+	public revoked!: boolean
+	public createdAt!: string
+
+	public constructor(props: Omit<RefreshToken, 'id' | 'createdAt'>) {
+		Object.assign(this, props)
+
+		if (this.id == null) {
+			this.id = ulid()
+		}
+
+		if (!this.createdAt) {
+			this.createdAt = new Date().toISOString()
+		}
+	}
+}

--- a/src/entities/User.Entity.ts
+++ b/src/entities/User.Entity.ts
@@ -1,5 +1,6 @@
 import { ulid } from 'ulid'
 import type { Otp } from './Otp.Entity'
+import type { RefreshToken } from './RefreshToken.Entity'
 
 export class User {
 	public readonly id!: string
@@ -11,6 +12,7 @@ export class User {
 	public rank?: number | null
 	public isTotpEnable!: boolean
 	public otps?: Otp[]
+	public refreshToken?: RefreshToken[]
 	public isActive!: boolean
 	public createdAt!: string
 	public deletedAt?: string | null

--- a/src/handlers/auth/users/OTPAuth.Handler.ts
+++ b/src/handlers/auth/users/OTPAuth.Handler.ts
@@ -1,6 +1,8 @@
 import type { ISanitizedAuthDTO } from '@src/dtos/Auth.DTO'
 import { AppError } from '@src/errors/AppErrors.Error'
+import { WebCryptoAES } from '@src/lib/webCryptoAES'
 import { OtpRepository } from '@src/repositories/auth/Otp.Repository'
+import { RefreshTokenRepository } from '@src/repositories/auth/RefreshToken.Repository'
 import { JWTManager } from '@src/services/auth/jwtManager/JWTManager.Service'
 import { OTPAuthService } from '@src/services/auth/otp/OTPAuth.Service'
 import type { Presenter } from '@src/types/presenter'
@@ -20,21 +22,34 @@ export const OtpAuthHandler = factory.createHandlers(
 			REFRESH_SECRET_KEY: c.env.REFRESH_SECRET_KEY,
 			AUTH_ISSUER: c.env.AUTH_ISSUER
 		})
+		const webCryptoAES = new WebCryptoAES({
+			secret: c.env.REFRESH_AES_KEY
+		})
 		const otpRepository = new OtpRepository(c.env.DB)
-		const userAuthService = new OTPAuthService(
+		const refreshTokenRepository = new RefreshTokenRepository(c.env.DB)
+		const otpAuthService = new OTPAuthService(
 			otpRepository,
 			jwtManager,
-			c.env.OTP_SECRET
+			c.env.OTP_SECRET,
+			refreshTokenRepository,
+			webCryptoAES
 		)
 
-		const data = await c.req.json().catch(() => {
+		const body = await c.req.json().catch(() => {
 			throw new AppError({
 				name: 'Bad Request',
 				message: 'Invalid JSON format in request body'
 			})
 		})
 
-		const user = await userAuthService.execute(data)
+		const userAgent = c.req.header('User-Agent')
+
+		const data = {
+			userAgent,
+			...body
+		}
+
+		const user = await otpAuthService.execute(data)
 
 		setCookie(c, 'refreshToken', user.token.refreshToken, {
 			secure: true,

--- a/src/repositories/auth/RefreshToken.Repository.ts
+++ b/src/repositories/auth/RefreshToken.Repository.ts
@@ -1,0 +1,133 @@
+import { refreshToken } from '@src/db/refreshToken.schema'
+import { users } from '@src/db/user.schema'
+import type {} from '@src/dtos/Pagination.DTO'
+import type { IRefreshTokenDTO } from '@src/dtos/RefreshToken.DTO'
+import type { IFindByParamsDTO } from '@src/dtos/Repositories.DTO'
+import { RefreshToken } from '@src/entities/RefreshToken.Entity'
+import type { User } from '@src/entities/User.Entity'
+import { AppError } from '@src/errors/AppErrors.Error'
+import { and, desc, eq, gt } from 'drizzle-orm'
+import { type DrizzleD1Database, drizzle } from 'drizzle-orm/d1'
+
+export class RefreshTokenRepository {
+	private db: DrizzleD1Database<Record<string, never>> & {
+		$client: D1Database
+	}
+
+	public constructor(D1: D1Database) {
+		this.db = drizzle(D1)
+	}
+
+	public async findManyByOr(
+		data: IFindByParamsDTO
+	): Promise<(User & { refreshToken: RefreshToken[] }) | null> {
+		const includeConditions = []
+
+		if (data.id) {
+			includeConditions.push(eq(refreshToken.userId, data.id))
+		}
+		if (data.revoked) {
+			includeConditions.push(eq(refreshToken.revoked, data.revoked))
+		}
+		if (data.noExpired) {
+			includeConditions.push(
+				gt(refreshToken.expiresAt, new Date().toISOString())
+			)
+		}
+
+		const process = await this.db
+			.select()
+			.from(users)
+			.innerJoin(refreshToken, eq(users.id, refreshToken.userId))
+			.where(and(...includeConditions))
+			.orderBy(desc(refreshToken.createdAt))
+
+		if (process.length === 0) {
+			return null
+		}
+
+		const opts = process.map((row) => {
+			return row.refreshToken
+		})
+
+		const user: User & { refreshToken: RefreshToken[] } = {
+			refreshToken: opts,
+			...process[0].users
+		}
+
+		return user
+	}
+
+	public async create(data: IRefreshTokenDTO): Promise<RefreshToken> {
+		const process = await this.db.insert(refreshToken).values(data)
+
+		if (process.error) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: process.error
+			})
+		}
+
+		const token = await this.db
+			.select()
+			.from(refreshToken)
+			.where(eq(refreshToken.id, data.id))
+			.limit(1)
+
+		if (token.length === 0) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: 'Token not found after update. Possible data inconsistency.'
+			})
+		}
+
+		return token[0]
+	}
+
+	public async update(data: RefreshToken): Promise<RefreshToken> {
+		const updateResult = await this.db
+			.update(refreshToken)
+			.set({
+				revoked: data.revoked
+			})
+			.where(eq(refreshToken.id, data.id))
+
+		if (updateResult.error) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message: updateResult.error
+			})
+		}
+
+		const queriedRefreshToken = await this.db
+			.select()
+			.from(refreshToken)
+			.where(eq(refreshToken.id, data.id))
+			.limit(1)
+
+		if (queriedRefreshToken.length === 0) {
+			throw new AppError({
+				name: 'Internal Server Error',
+				message:
+					'Refresh Token not found after update. Possible data inconsistency.'
+			})
+		}
+
+		const updatedRefreshToken = new RefreshToken(queriedRefreshToken[0])
+
+		return updatedRefreshToken
+	}
+
+	public async delete(id: string): Promise<RefreshToken[] | null> {
+		const process = await this.db
+			.delete(refreshToken)
+			.where(eq(refreshToken.userId, id))
+			.returning()
+
+		if (process.length === 0) {
+			return null
+		}
+
+		return process
+	}
+}

--- a/src/services/auth/jwtManager/JWTManager.Service.ts
+++ b/src/services/auth/jwtManager/JWTManager.Service.ts
@@ -27,9 +27,10 @@ export class JWTManager {
 		accessToken: string
 		refreshToken: string
 		accessTokenExp: number
+		refreshTokenExp: number
 	}> {
 		const payloadAccessToken = {
-			id,
+			sub: id,
 			name,
 			username,
 			iss: this.issuer,
@@ -38,7 +39,7 @@ export class JWTManager {
 		}
 
 		const payloadRefreshToken = {
-			id,
+			sub: id,
 			iss: this.issuer,
 			iat: Math.floor(Date.now() / 1000),
 			exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30
@@ -47,6 +48,11 @@ export class JWTManager {
 		const accessToken = await sign(payloadAccessToken, this.userSecretyKey)
 		const refreshToken = await sign(payloadRefreshToken, this.refreshSecretKey)
 
-		return { accessToken, refreshToken, accessTokenExp: payloadAccessToken.exp }
+		return {
+			accessToken,
+			refreshToken,
+			accessTokenExp: payloadAccessToken.exp,
+			refreshTokenExp: payloadRefreshToken.exp
+		}
 	}
 }

--- a/src/validations/auth/OTPAuth.Validation.ts
+++ b/src/validations/auth/OTPAuth.Validation.ts
@@ -4,7 +4,8 @@ export const OTPAuthSchema = validator.schema(
 	{
 		username: validator.string().max(256).nullable(),
 		email: validator.string().email().max(256).nullable(),
-		token: validator.string().max(10).min(1)
+		token: validator.string().max(10).min(1),
+		userAgent: validator.string().max(256).nullable()
 	},
 	{
 		strict: true

--- a/tests/handlers/auth/otpAuth/Success.test.ts
+++ b/tests/handlers/auth/otpAuth/Success.test.ts
@@ -50,7 +50,8 @@ describe('User OTP authentication handler E2E', () => {
 
 	const headers = {
 		'Content-Type': 'application/json',
-		'X-CSRF-Token': 'mock-csrf-token'
+		'X-CSRF-Token': 'mock-csrf-token',
+		'User-Agent': 'Vitest'
 	}
 
 	beforeAll(async () => {

--- a/tests/handlers/auth/users/Success.test.ts
+++ b/tests/handlers/auth/users/Success.test.ts
@@ -11,7 +11,8 @@ describe('User authentication handler E2E', () => {
 
 	const headers = {
 		'Content-Type': 'application/json',
-		'X-CSRF-Token': 'mock-csrf-token'
+		'X-CSRF-Token': 'mock-csrf-token',
+		'User-Agent': 'Vitest'
 	}
 
 	beforeAll(async () => {


### PR DESCRIPTION
## Changes Made

This PR updates the `UserAuthService` and `OTPAuthService` to encrypt the refresh token using the `WebCryptoAES` library. The encrypted token is then stored in the `refreshToken` database table after all necessary validations and checks are performed.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
 - [x] New feature 
- [x] _**Breaking change**_ (JWTManager service now returns refresh token expiration date) 
<!-- - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [ ] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
