### PR TITLE
refactor(RefreshTokenHandler): Send accessToken in Bearer Header for Refresh Token API and Fix Type Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,9 @@ This endpoint refreshes an expired access token by validating the provided refre
 > |--------------|-----------|------------------------------------------------------------------------------------------------------|
 > | Content-Type |  yes      | Required for operations with a request body. The value is application/. Where the 'format' is 'json'.|
 > | X-CSRF-Token |  yes      | A CSRF token to protect against cross-site request forgery attacks. Must be included in the request.|
+> | Authorization |  yes      | Access Token, a Bearer token in the format `Bearer <JWT>` for authenticating the request and ensuring access.|
 
 **Note**: The `refreshToken` is automatically sent by the browser in the `Cookie` header if the client has a valid session. It does not need to be manually set in the request.
-
-> #### Body Schema
-> | name          |  type     | Required | description                         |
-> |---------------|-----------|----------|-------------------------------------|
-> | accessToken      |  string   |**yes** | 	The current expired JWT access token. |
 
 #### Response 
 

--- a/src/handlers/auth/users/GenerateOtpAuth.Handler.ts
+++ b/src/handlers/auth/users/GenerateOtpAuth.Handler.ts
@@ -25,7 +25,7 @@ export const GenerateOtpAuthUrlHandler = factory.createHandlers(
 			otpRepository
 		)
 
-		const id = c.req.param('id')
+		const id = c.req.param('id') ?? ''
 
 		const otpUrl = await generateOtpAuthUrlService.execute({ id })
 

--- a/src/handlers/auth/users/RefreshToken.Handler.ts
+++ b/src/handlers/auth/users/RefreshToken.Handler.ts
@@ -1,5 +1,4 @@
 import type { ISanitizedAuthDTO } from '@src/dtos/Auth.DTO'
-import { AppError } from '@src/errors/AppErrors.Error'
 import { WebCryptoAES } from '@src/lib/webCryptoAES'
 import { RefreshTokenRepository } from '@src/repositories/auth/RefreshToken.Repository'
 import { JWTManager } from '@src/services/auth/jwtManager/JWTManager.Service'
@@ -34,18 +33,14 @@ export const RefreshTokenHandler = factory.createHandlers(
 			webCryptoAES
 		)
 
-		const accessToken = await c.req.json().catch(() => {
-			throw new AppError({
-				name: 'Bad Request',
-				message: 'Invalid JSON format in request body'
-			})
-		})
+		const authorization = c.req.header('authorization') ?? ''
+		const accessToken = authorization.split(' ')[1]
 
-		const userAgent = c.req.header('User-Agent')
+		const userAgent = c.req.header('User-Agent') ?? ''
 
-		const refreshToken = getCookie(c, 'refreshToken')
+		const refreshToken = getCookie(c, 'refreshToken') ?? ''
 
-		const data = { refreshToken, userAgent, ...accessToken }
+		const data = { refreshToken, userAgent, accessToken }
 
 		const user = await refreshTokenService.execute(data)
 

--- a/src/handlers/error/Errors.Handler.ts
+++ b/src/handlers/error/Errors.Handler.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import type { HTTPResponseError } from 'hono/types'
-import type { StatusCode } from 'hono/utils/http-status'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import {
 	JwtAlgorithmNotImplemented,
 	JwtHeaderInvalid,
@@ -16,7 +16,7 @@ export const errorsHandler = (
 	error: Error | HTTPResponseError,
 	c: Context
 ): Response | Promise<Response> => {
-	const errorMap: Record<string, { status: StatusCode }> = {
+	const errorMap: Record<string, { status: ContentfulStatusCode }> = {
 		'Bad Request': { status: 400 },
 		Unauthorized: { status: 401 },
 		Forbidden: { status: 403 },

--- a/src/handlers/users/DeleteUser/DeleteUser.Handler.ts
+++ b/src/handlers/users/DeleteUser/DeleteUser.Handler.ts
@@ -15,7 +15,7 @@ export const DeleteUserHandler = factory.createHandlers(
 		const usersRepository = new UserRepository(c.env.DB)
 		const deleteUserService = new DeleteUserService(usersRepository)
 
-		const id = c.req.param('id')
+		const id = c.req.param('id') ?? ''
 
 		const data = { id }
 

--- a/src/handlers/users/GetUserById/GetUserById.Handler.ts
+++ b/src/handlers/users/GetUserById/GetUserById.Handler.ts
@@ -16,7 +16,7 @@ export const GetUserByIdHandler = factory.createHandlers(
 		const usersRepository = new UserRepository(c.env.DB)
 		const getUserByIdService = new GetUserByIdService(usersRepository)
 
-		const id = c.req.param('id')
+		const id = c.req.param('id') ?? ''
 
 		const queryParameters = c.req.query('includeDeleted')
 

--- a/tests/handlers/auth/refreshToken/NotFound.failure.test.ts
+++ b/tests/handlers/auth/refreshToken/NotFound.failure.test.ts
@@ -39,10 +39,6 @@ describe('Refresh Token not found failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -51,9 +47,9 @@ describe('Refresh Token not found failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)

--- a/tests/handlers/auth/refreshToken/Signature.failure.test.ts
+++ b/tests/handlers/auth/refreshToken/Signature.failure.test.ts
@@ -39,10 +39,6 @@ describe('Refresh Token signature failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -51,9 +47,9 @@ describe('Refresh Token signature failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -87,10 +83,6 @@ describe('Refresh Token signature failure cases E2E', () => {
 		const accessTokenGen = await sign(payloadAccessToken, env.USER_SECRET_KEY)
 		const refreshTokenGen = await sign(payloadRefreshToken, 'invalid-signature')
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -99,9 +91,9 @@ describe('Refresh Token signature failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)

--- a/tests/handlers/auth/refreshToken/SubMatch.failure.test.ts
+++ b/tests/handlers/auth/refreshToken/SubMatch.failure.test.ts
@@ -39,10 +39,6 @@ describe('Refresh Token Sub Match failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -51,9 +47,9 @@ describe('Refresh Token Sub Match failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)

--- a/tests/handlers/auth/refreshToken/Success.test.ts
+++ b/tests/handlers/auth/refreshToken/Success.test.ts
@@ -103,10 +103,6 @@ describe('Refresh Token success cases handler E2E', () => {
 
 		await db.insert(refreshToken).values(refreshTokenInstances)
 
-		const payload = JSON.stringify({
-			accessToken: generatedAccessToken
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -115,9 +111,9 @@ describe('Refresh Token success cases handler E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${generatedAccessToken}`,
 					Cookie: `refreshToken=${generatedRefreshToken}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)

--- a/tests/handlers/auth/refreshToken/TokenExp.failure.test.ts
+++ b/tests/handlers/auth/refreshToken/TokenExp.failure.test.ts
@@ -39,10 +39,6 @@ describe('Refresh Token expired failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -51,9 +47,9 @@ describe('Refresh Token expired failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -90,10 +86,6 @@ describe('Refresh Token expired failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -102,9 +94,9 @@ describe('Refresh Token expired failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)

--- a/tests/handlers/auth/refreshToken/TokenStatus.failure.test.ts
+++ b/tests/handlers/auth/refreshToken/TokenStatus.failure.test.ts
@@ -90,10 +90,6 @@ describe('Refresh Token status failure cases E2E', () => {
 
 		await db.insert(refreshToken).values(refreshTokenInstance)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -102,9 +98,9 @@ describe('Refresh Token status failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)

--- a/tests/handlers/auth/refreshToken/ValidateToken.failure.test.ts
+++ b/tests/handlers/auth/refreshToken/ValidateToken.failure.test.ts
@@ -39,10 +39,6 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -51,9 +47,9 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -90,10 +86,6 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -102,9 +94,9 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -141,10 +133,6 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -153,9 +141,9 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -192,10 +180,6 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -204,9 +188,9 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -243,10 +227,6 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -255,9 +235,9 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -294,10 +274,6 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 			env.REFRESH_SECRET_KEY
 		)
 
-		const payload = JSON.stringify({
-			accessToken: accessTokenGen
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -306,9 +282,9 @@ describe('Refresh Token Validate Token failure cases E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: `Bearer ${accessTokenGen}`,
 					Cookie: `refreshToken=${refreshTokenGen}; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict`
-				},
-				body: payload
+				}
 			},
 			env
 		)

--- a/tests/handlers/auth/refreshToken/Validation.failure.test.ts
+++ b/tests/handlers/auth/refreshToken/Validation.failure.test.ts
@@ -43,15 +43,13 @@ describe('Refresh Token Input Validation E2E', () => {
 			success: false,
 			message: 'Validation failed',
 			cause: {
-				cause: 'is not string',
+				cause: 'is not nullable',
 				field: 'accessToken'
 			}
 		})
 	})
 
-	test('should fail with accessToken not string', async () => {
-		const payload = JSON.stringify({})
-
+	test('should fail with accessToken undefined', async () => {
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -62,8 +60,7 @@ describe('Refresh Token Input Validation E2E', () => {
 					'User-Agent': 'Vitest',
 					Cookie:
 						'refreshToken=324234234; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict'
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -82,10 +79,6 @@ describe('Refresh Token Input Validation E2E', () => {
 	})
 
 	test('should fail with undefined refreshToken', async () => {
-		const payload = JSON.stringify({
-			accessToken: '123'
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -93,9 +86,9 @@ describe('Refresh Token Input Validation E2E', () => {
 				headers: {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
+					Authorization: 'Bearer Mocktoken',
 					'User-Agent': 'Vitest'
-				},
-				body: payload
+				}
 			},
 			env
 		)
@@ -107,17 +100,13 @@ describe('Refresh Token Input Validation E2E', () => {
 			success: false,
 			message: 'Validation failed',
 			cause: {
-				cause: 'is not nullable',
+				cause: 'is not min',
 				field: 'refreshToken'
 			}
 		})
 	})
 
 	test('should fail with less them min refreshToken', async () => {
-		const payload = JSON.stringify({
-			accessToken: '123'
-		})
-
 		const res = await app.request(
 			'/users/auth/refresh',
 			{
@@ -126,10 +115,10 @@ describe('Refresh Token Input Validation E2E', () => {
 					'Content-Type': 'application/json',
 					'X-CSRF-Token': 'mock-csrf-token',
 					'User-Agent': 'Vitest',
+					Authorization: 'Bearer Mocktoken',
 					Cookie:
 						'refreshToken=; Max-Age=2332800; Path=/users/auth/refresh; HttpOnly; Secure; SameSite=Strict'
-				},
-				body: payload
+				}
 			},
 			env
 		)


### PR DESCRIPTION
## Changes Made

This PR updates the method of sending the `accessToken` to the refresh token API by including it in the `Authorization` bearer header. This change ensures better aligns with standard authentication practices.

Additionally, default empty values were added to the id request parameters to prevent potential type errors. The status type in the `errorsHandler` was also updated to `ContentfulStatusCode` to improve type safety and ensure consistency with error handling.

## Changes Type

<!-- Uncomment the line below that corresponds to the changes type made in the PR. -->

<!-- - [x] Bug fix -->
<!-- - [x] New feature -->
 - [x] _**Breaking change**_ (Access Token now is send in the Authorization bearer token in the refresh token api) 
 - [x] Documentation update -->

## Checklist:

- [x] The changes do not generate new error logs or warnings.
- [ ] I have added tests that prove the fix or new feature works as expected.
- [x] Both new and existing tests pass locally.
